### PR TITLE
Remove deprecated TypeScript configuration option

### DIFF
--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -21,8 +21,7 @@
     "types": ["vite/client"],
     "paths": {
       "@/*": ["./src/*"]
-    },
-    "ignoreDeprecations": "6.0"
+    }
   },
   "include": ["src"],
   "references": [


### PR DESCRIPTION
Remove the `ignoreDeprecations` option from the TypeScript configuration to clean up the settings.