### PR TITLE
fix: WhatsApp template UX improvements and provider unit tests

### DIFF
--- a/internal/infrastructure/providers/whatsapp_provider.go
+++ b/internal/infrastructure/providers/whatsapp_provider.go
@@ -123,9 +123,13 @@ func (p *WhatsAppProvider) Send(ctx context.Context, notif *notification.Notific
 	contentSid, _ := notif.Content.Data["content_sid"].(string)
 	if contentSid != "" {
 		data.Set("ContentSid", contentSid)
+		// content_variables may arrive as map[string]interface{} (from standard send)
+		// or as a JSON string (from quick-send UI). Handle both.
 		if vars, ok := notif.Content.Data["content_variables"].(map[string]interface{}); ok {
 			varsJSON, _ := json.Marshal(vars)
 			data.Set("ContentVariables", string(varsJSON))
+		} else if varsStr, ok := notif.Content.Data["content_variables"].(string); ok && varsStr != "" {
+			data.Set("ContentVariables", varsStr)
 		}
 		p.logger.Debug("Using Twilio Content Template",
 			zap.String("notification_id", notif.NotificationID),

--- a/internal/infrastructure/providers/whatsapp_provider_test.go
+++ b/internal/infrastructure/providers/whatsapp_provider_test.go
@@ -1,0 +1,723 @@
+package providers
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/the-monkeys/freerangenotify/internal/domain/application"
+	"github.com/the-monkeys/freerangenotify/internal/domain/notification"
+	"github.com/the-monkeys/freerangenotify/internal/domain/user"
+	"go.uber.org/zap/zaptest"
+)
+
+// newTestWhatsAppProvider creates a provider pointing at a test server.
+func newTestWhatsAppProvider(t *testing.T, serverURL string) *WhatsAppProvider {
+	t.Helper()
+	p, err := NewWhatsAppProvider(WhatsAppConfig{
+		Config:     Config{Timeout: 5 * time.Second, MaxRetries: 0},
+		AccountSID: "ACtest123",
+		AuthToken:  "token456",
+		FromNumber: "+14155238886",
+	}, zaptest.NewLogger(t))
+	require.NoError(t, err)
+	// Override httpClient to route to test server (Twilio URL is built at
+	// send time so we intercept via a custom transport).
+	p.httpClient = &http.Client{
+		Timeout:   5 * time.Second,
+		Transport: &rewriteTransport{target: serverURL},
+	}
+	return p
+}
+
+// rewriteTransport redirects all requests to the test server URL.
+type rewriteTransport struct {
+	target string
+}
+
+func (t *rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	parsed, _ := url.Parse(t.target)
+	req.URL.Scheme = parsed.Scheme
+	req.URL.Host = parsed.Host
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+func baseNotification() *notification.Notification {
+	return &notification.Notification{
+		NotificationID: "notif-001",
+		Content: notification.Content{
+			Title: "Hello",
+			Body:  "World",
+		},
+	}
+}
+
+func baseUser() *user.User {
+	return &user.User{
+		UserID: "user-001",
+		Phone:  "+15551234567",
+	}
+}
+
+// twilioSuccess returns a 201 JSON body mimicking Twilio's Messages.json response.
+func twilioSuccess(sid string) []byte {
+	b, _ := json.Marshal(map[string]interface{}{
+		"sid":    sid,
+		"status": "queued",
+	})
+	return b
+}
+
+// ─── Nil / empty user ────────────────────────────────────────────────────────
+
+func TestWhatsAppProvider_Send_NilUser(t *testing.T) {
+	p, _ := NewWhatsAppProvider(WhatsAppConfig{
+		AccountSID: "AC1", AuthToken: "tok", FromNumber: "+1",
+	}, zaptest.NewLogger(t))
+
+	result, err := p.Send(context.Background(), baseNotification(), nil)
+	assert.NoError(t, err)
+	assert.False(t, result.Success)
+	assert.Equal(t, ErrorTypeInvalid, result.ErrorType)
+	assert.Contains(t, result.Error.Error(), "no phone number")
+}
+
+func TestWhatsAppProvider_Send_EmptyPhone(t *testing.T) {
+	p, _ := NewWhatsAppProvider(WhatsAppConfig{
+		AccountSID: "AC1", AuthToken: "tok", FromNumber: "+1",
+	}, zaptest.NewLogger(t))
+	usr := &user.User{UserID: "u1", Phone: ""}
+
+	result, err := p.Send(context.Background(), baseNotification(), usr)
+	assert.NoError(t, err)
+	assert.False(t, result.Success)
+	assert.Equal(t, ErrorTypeInvalid, result.ErrorType)
+}
+
+// ─── Missing credentials ─────────────────────────────────────────────────────
+
+func TestWhatsAppProvider_Send_MissingAccountSID(t *testing.T) {
+	p, _ := NewWhatsAppProvider(WhatsAppConfig{
+		AccountSID: "", AuthToken: "tok", FromNumber: "+1",
+	}, zaptest.NewLogger(t))
+
+	result, err := p.Send(context.Background(), baseNotification(), baseUser())
+	assert.NoError(t, err)
+	assert.False(t, result.Success)
+	assert.Equal(t, ErrorTypeConfiguration, result.ErrorType)
+	assert.Contains(t, result.Error.Error(), "credentials not configured")
+}
+
+func TestWhatsAppProvider_Send_MissingAuthToken(t *testing.T) {
+	p, _ := NewWhatsAppProvider(WhatsAppConfig{
+		AccountSID: "AC1", AuthToken: "", FromNumber: "+1",
+	}, zaptest.NewLogger(t))
+
+	result, err := p.Send(context.Background(), baseNotification(), baseUser())
+	assert.NoError(t, err)
+	assert.False(t, result.Success)
+	assert.Equal(t, ErrorTypeConfiguration, result.ErrorType)
+}
+
+func TestWhatsAppProvider_Send_MissingFromNumber(t *testing.T) {
+	p, _ := NewWhatsAppProvider(WhatsAppConfig{
+		AccountSID: "AC1", AuthToken: "tok", FromNumber: "",
+	}, zaptest.NewLogger(t))
+
+	result, err := p.Send(context.Background(), baseNotification(), baseUser())
+	assert.NoError(t, err)
+	assert.False(t, result.Success)
+	assert.Equal(t, ErrorTypeConfiguration, result.ErrorType)
+	assert.Contains(t, result.Error.Error(), "sender number not configured")
+}
+
+// ─── Free-form text mode (successful) ────────────────────────────────────────
+
+func TestWhatsAppProvider_Send_FreeFormText(t *testing.T) {
+	var captured url.Values
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		captured, _ = url.ParseQuery(string(body))
+
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "application/x-www-form-urlencoded", r.Header.Get("Content-Type"))
+
+		// Verify basic auth
+		u, p, ok := r.BasicAuth()
+		assert.True(t, ok)
+		assert.Equal(t, "ACtest123", u)
+		assert.Equal(t, "token456", p)
+
+		w.WriteHeader(http.StatusCreated)
+		w.Write(twilioSuccess("SM123"))
+	}))
+	defer server.Close()
+
+	p := newTestWhatsAppProvider(t, server.URL)
+	notif := baseNotification()
+	notif.Content.Title = "Order Update"
+	notif.Content.Body = "Your order #123 has shipped."
+
+	result, err := p.Send(context.Background(), notif, baseUser())
+
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+	assert.Equal(t, "SM123", result.ProviderMessageID)
+	assert.Equal(t, CredSourceSystem, result.Metadata["credential_source"])
+	assert.Equal(t, "whatsapp", result.Metadata["billing_channel"])
+
+	// Verify Twilio form data
+	assert.Equal(t, "whatsapp:+15551234567", captured.Get("To"))
+	assert.Equal(t, "whatsapp:+14155238886", captured.Get("From"))
+	assert.Equal(t, "*Order Update*\n\nYour order #123 has shipped.", captured.Get("Body"))
+	assert.Empty(t, captured.Get("ContentSid"))
+}
+
+func TestWhatsAppProvider_Send_FreeFormBodyOnly(t *testing.T) {
+	var captured url.Values
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		captured, _ = url.ParseQuery(string(body))
+		w.WriteHeader(http.StatusCreated)
+		w.Write(twilioSuccess("SM124"))
+	}))
+	defer server.Close()
+
+	p := newTestWhatsAppProvider(t, server.URL)
+	notif := baseNotification()
+	notif.Content.Title = "" // No title — body only
+	notif.Content.Body = "Plain message"
+
+	result, err := p.Send(context.Background(), notif, baseUser())
+
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+	assert.Equal(t, "Plain message", captured.Get("Body"))
+}
+
+func TestWhatsAppProvider_Send_FreeFormWithMedia(t *testing.T) {
+	var captured url.Values
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		captured, _ = url.ParseQuery(string(body))
+		w.WriteHeader(http.StatusCreated)
+		w.Write(twilioSuccess("SM125"))
+	}))
+	defer server.Close()
+
+	p := newTestWhatsAppProvider(t, server.URL)
+	notif := baseNotification()
+	notif.Content.Title = ""
+	notif.Content.Body = "Check this out"
+	notif.Content.MediaURL = "https://example.com/image.jpg"
+
+	result, err := p.Send(context.Background(), notif, baseUser())
+
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+	assert.Equal(t, "Check this out", captured.Get("Body"))
+	assert.Equal(t, "https://example.com/image.jpg", captured.Get("MediaUrl"))
+}
+
+// ─── Content Template mode ───────────────────────────────────────────────────
+
+func TestWhatsAppProvider_Send_ContentTemplate_MapVariables(t *testing.T) {
+	var captured url.Values
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		captured, _ = url.ParseQuery(string(body))
+		w.WriteHeader(http.StatusCreated)
+		w.Write(twilioSuccess("SM200"))
+	}))
+	defer server.Close()
+
+	p := newTestWhatsAppProvider(t, server.URL)
+	notif := baseNotification()
+	notif.Content.Data = map[string]interface{}{
+		"content_sid": "HX123abc",
+		"content_variables": map[string]interface{}{
+			"1": "Dave",
+			"2": "12345",
+		},
+	}
+
+	result, err := p.Send(context.Background(), notif, baseUser())
+
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+	assert.Equal(t, "HX123abc", captured.Get("ContentSid"))
+	assert.Empty(t, captured.Get("Body"), "Body should NOT be set in template mode")
+	assert.Empty(t, captured.Get("MediaUrl"), "MediaUrl should NOT be set in template mode")
+
+	// Parse content_variables JSON
+	var vars map[string]string
+	require.NoError(t, json.Unmarshal([]byte(captured.Get("ContentVariables")), &vars))
+	assert.Equal(t, "Dave", vars["1"])
+	assert.Equal(t, "12345", vars["2"])
+}
+
+func TestWhatsAppProvider_Send_ContentTemplate_StringVariables(t *testing.T) {
+	var captured url.Values
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		captured, _ = url.ParseQuery(string(body))
+		w.WriteHeader(http.StatusCreated)
+		w.Write(twilioSuccess("SM201"))
+	}))
+	defer server.Close()
+
+	p := newTestWhatsAppProvider(t, server.URL)
+	notif := baseNotification()
+	notif.Content.Data = map[string]interface{}{
+		"content_sid":       "HX456def",
+		"content_variables": `{"1":"Dave","2":"order-789"}`,
+	}
+
+	result, err := p.Send(context.Background(), notif, baseUser())
+
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+	assert.Equal(t, "HX456def", captured.Get("ContentSid"))
+	assert.Equal(t, `{"1":"Dave","2":"order-789"}`, captured.Get("ContentVariables"))
+}
+
+func TestWhatsAppProvider_Send_ContentTemplate_NoVariables(t *testing.T) {
+	var captured url.Values
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		captured, _ = url.ParseQuery(string(body))
+		w.WriteHeader(http.StatusCreated)
+		w.Write(twilioSuccess("SM202"))
+	}))
+	defer server.Close()
+
+	p := newTestWhatsAppProvider(t, server.URL)
+	notif := baseNotification()
+	notif.Content.Data = map[string]interface{}{
+		"content_sid": "HX789",
+	}
+
+	result, err := p.Send(context.Background(), notif, baseUser())
+
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+	assert.Equal(t, "HX789", captured.Get("ContentSid"))
+	assert.Empty(t, captured.Get("ContentVariables"))
+}
+
+// ─── WhatsApp prefix handling ────────────────────────────────────────────────
+
+func TestWhatsAppProvider_Send_PrefixAlreadyPresent(t *testing.T) {
+	var captured url.Values
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		captured, _ = url.ParseQuery(string(body))
+		w.WriteHeader(http.StatusCreated)
+		w.Write(twilioSuccess("SM300"))
+	}))
+	defer server.Close()
+
+	p := newTestWhatsAppProvider(t, server.URL)
+	// FromNumber already has prefix
+	p.config.FromNumber = "whatsapp:+14155238886"
+
+	usr := &user.User{UserID: "u2", Phone: "whatsapp:+15559998888"}
+
+	result, err := p.Send(context.Background(), baseNotification(), usr)
+
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+	// Should NOT double-prefix
+	assert.Equal(t, "whatsapp:+15559998888", captured.Get("To"))
+	assert.Equal(t, "whatsapp:+14155238886", captured.Get("From"))
+}
+
+// ─── Per-app credential override (BYOC) ──────────────────────────────────────
+
+func TestWhatsAppProvider_Send_PerAppCredentials(t *testing.T) {
+	var capturedAuth [2]string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		u, p, _ := r.BasicAuth()
+		capturedAuth = [2]string{u, p}
+
+		body, _ := io.ReadAll(r.Body)
+		vals, _ := url.ParseQuery(string(body))
+		assert.Equal(t, "whatsapp:+19998887777", vals.Get("From"))
+
+		w.WriteHeader(http.StatusCreated)
+		w.Write(twilioSuccess("SM400"))
+	}))
+	defer server.Close()
+
+	p := newTestWhatsAppProvider(t, server.URL)
+
+	appCfg := &application.WhatsAppAppConfig{
+		AccountSID: "ACappOverride",
+		AuthToken:  "appTokenOverride",
+		FromNumber: "+19998887777",
+	}
+	ctx := context.WithValue(context.Background(), WhatsAppConfigKey, appCfg)
+
+	result, err := p.Send(ctx, baseNotification(), baseUser())
+
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+	assert.Equal(t, "ACappOverride", capturedAuth[0])
+	assert.Equal(t, "appTokenOverride", capturedAuth[1])
+	assert.Equal(t, CredSourceBYOC, result.Metadata["credential_source"])
+}
+
+func TestWhatsAppProvider_Send_PerAppCredentials_PartialOverride(t *testing.T) {
+	// Per-app config with empty auth token — should fall back to global creds
+	var capturedAuth [2]string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		u, p, _ := r.BasicAuth()
+		capturedAuth = [2]string{u, p}
+		w.WriteHeader(http.StatusCreated)
+		w.Write(twilioSuccess("SM401"))
+	}))
+	defer server.Close()
+
+	p := newTestWhatsAppProvider(t, server.URL)
+
+	appCfg := &application.WhatsAppAppConfig{
+		AccountSID: "ACpartial",
+		AuthToken:  "", // empty — should NOT override
+	}
+	ctx := context.WithValue(context.Background(), WhatsAppConfigKey, appCfg)
+
+	result, err := p.Send(ctx, baseNotification(), baseUser())
+
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+	// Should use global creds since AuthToken is empty
+	assert.Equal(t, "ACtest123", capturedAuth[0])
+	assert.Equal(t, "token456", capturedAuth[1])
+	assert.Equal(t, CredSourceSystem, result.Metadata["credential_source"])
+}
+
+func TestWhatsAppProvider_Send_PerAppCredentials_NoFromNumber(t *testing.T) {
+	// Per-app config without FromNumber — should keep global from number
+	var captured url.Values
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		captured, _ = url.ParseQuery(string(body))
+		w.WriteHeader(http.StatusCreated)
+		w.Write(twilioSuccess("SM402"))
+	}))
+	defer server.Close()
+
+	p := newTestWhatsAppProvider(t, server.URL)
+
+	appCfg := &application.WhatsAppAppConfig{
+		AccountSID: "ACappNoFrom",
+		AuthToken:  "appToken2",
+		FromNumber: "", // empty — keep global
+	}
+	ctx := context.WithValue(context.Background(), WhatsAppConfigKey, appCfg)
+
+	result, err := p.Send(ctx, baseNotification(), baseUser())
+
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+	assert.Equal(t, "whatsapp:+14155238886", captured.Get("From"))
+}
+
+// ─── Twilio error responses ──────────────────────────────────────────────────
+
+func TestWhatsAppProvider_Send_TwilioErrorCode(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"error_code":    63016,
+			"error_message": "Template not found",
+		})
+	}))
+	defer server.Close()
+
+	p := newTestWhatsAppProvider(t, server.URL)
+
+	result, err := p.Send(context.Background(), baseNotification(), baseUser())
+
+	assert.NoError(t, err)
+	assert.False(t, result.Success)
+	assert.Equal(t, ErrorTypeProviderAPI, result.ErrorType)
+	assert.Contains(t, result.Error.Error(), "63016")
+	assert.Contains(t, result.Error.Error(), "Template not found")
+}
+
+func TestWhatsAppProvider_Send_TwilioCodeMessage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"code":    20003,
+			"message": "Authenticate",
+		})
+	}))
+	defer server.Close()
+
+	p := newTestWhatsAppProvider(t, server.URL)
+
+	result, err := p.Send(context.Background(), baseNotification(), baseUser())
+
+	assert.NoError(t, err)
+	assert.False(t, result.Success)
+	assert.Contains(t, result.Error.Error(), "20003")
+	assert.Contains(t, result.Error.Error(), "Authenticate")
+}
+
+func TestWhatsAppProvider_Send_TwilioPlainMessage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"message": "Permission denied",
+		})
+	}))
+	defer server.Close()
+
+	p := newTestWhatsAppProvider(t, server.URL)
+
+	result, err := p.Send(context.Background(), baseNotification(), baseUser())
+
+	assert.NoError(t, err)
+	assert.False(t, result.Success)
+	assert.Contains(t, result.Error.Error(), "Permission denied")
+}
+
+func TestWhatsAppProvider_Send_TwilioEmptyErrorBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	p := newTestWhatsAppProvider(t, server.URL)
+
+	result, err := p.Send(context.Background(), baseNotification(), baseUser())
+
+	assert.NoError(t, err)
+	assert.False(t, result.Success)
+	assert.Contains(t, result.Error.Error(), "status 500")
+}
+
+func TestWhatsAppProvider_Send_TwilioMalformedJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte("not-json"))
+	}))
+	defer server.Close()
+
+	p := newTestWhatsAppProvider(t, server.URL)
+
+	result, err := p.Send(context.Background(), baseNotification(), baseUser())
+
+	// Still succeeds (status 201) but ProviderMessageID falls back
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+	assert.Contains(t, result.ProviderMessageID, "whatsapp-notif-001")
+}
+
+// ─── Network errors ──────────────────────────────────────────────────────────
+
+func TestWhatsAppProvider_Send_NetworkError(t *testing.T) {
+	p := newTestWhatsAppProvider(t, "http://127.0.0.1:1") // nothing listening
+
+	result, err := p.Send(context.Background(), baseNotification(), baseUser())
+
+	assert.NoError(t, err) // Provider returns Result, not Go error
+	assert.False(t, result.Success)
+	assert.Equal(t, ErrorTypeNetwork, result.ErrorType)
+}
+
+// ─── Context cancellation ────────────────────────────────────────────────────
+
+func TestWhatsAppProvider_Send_ContextCancelled(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(2 * time.Second) // simulate slow
+		w.WriteHeader(http.StatusCreated)
+		w.Write(twilioSuccess("SM999"))
+	}))
+	defer server.Close()
+
+	p := newTestWhatsAppProvider(t, server.URL)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	result, err := p.Send(ctx, baseNotification(), baseUser())
+
+	assert.NoError(t, err)
+	assert.False(t, result.Success)
+	assert.Equal(t, ErrorTypeNetwork, result.ErrorType)
+}
+
+// ─── Twilio status metadata ─────────────────────────────────────────────────
+
+func TestWhatsAppProvider_Send_TwilioStatusInMetadata(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"sid":    "SM500",
+			"status": "queued",
+		})
+	}))
+	defer server.Close()
+
+	p := newTestWhatsAppProvider(t, server.URL)
+
+	result, err := p.Send(context.Background(), baseNotification(), baseUser())
+
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+	assert.Equal(t, "queued", result.Metadata["twilio_status"])
+}
+
+// ─── Provider interface methods ──────────────────────────────────────────────
+
+func TestWhatsAppProvider_GetName(t *testing.T) {
+	p, _ := NewWhatsAppProvider(WhatsAppConfig{}, zaptest.NewLogger(t))
+	assert.Equal(t, "whatsapp", p.GetName())
+}
+
+func TestWhatsAppProvider_GetSupportedChannel(t *testing.T) {
+	p, _ := NewWhatsAppProvider(WhatsAppConfig{}, zaptest.NewLogger(t))
+	assert.Equal(t, notification.ChannelWhatsApp, p.GetSupportedChannel())
+}
+
+func TestWhatsAppProvider_IsHealthy(t *testing.T) {
+	p, _ := NewWhatsAppProvider(WhatsAppConfig{}, zaptest.NewLogger(t))
+	assert.True(t, p.IsHealthy(context.Background()))
+}
+
+func TestWhatsAppProvider_Close(t *testing.T) {
+	p, _ := NewWhatsAppProvider(WhatsAppConfig{}, zaptest.NewLogger(t))
+	assert.NoError(t, p.Close())
+}
+
+// ─── NewWhatsAppProvider defaults ────────────────────────────────────────────
+
+func TestNewWhatsAppProvider_DefaultTimeout(t *testing.T) {
+	p, err := NewWhatsAppProvider(WhatsAppConfig{
+		AccountSID: "AC1", AuthToken: "t", FromNumber: "+1",
+	}, zaptest.NewLogger(t))
+	require.NoError(t, err)
+	assert.Equal(t, 15*time.Second, p.httpClient.Timeout)
+}
+
+func TestNewWhatsAppProvider_CustomTimeout(t *testing.T) {
+	p, err := NewWhatsAppProvider(WhatsAppConfig{
+		Config:     Config{Timeout: 30 * time.Second},
+		AccountSID: "AC1", AuthToken: "t", FromNumber: "+1",
+	}, zaptest.NewLogger(t))
+	require.NoError(t, err)
+	assert.Equal(t, 30*time.Second, p.httpClient.Timeout)
+}
+
+// ─── Twilio 200 OK (accepted by some endpoints) ─────────────────────────────
+
+func TestWhatsAppProvider_Send_Status200OK(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write(twilioSuccess("SM600"))
+	}))
+	defer server.Close()
+
+	p := newTestWhatsAppProvider(t, server.URL)
+
+	result, err := p.Send(context.Background(), baseNotification(), baseUser())
+
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+	assert.Equal(t, "SM600", result.ProviderMessageID)
+}
+
+// ─── Missing SID in successful response ──────────────────────────────────────
+
+func TestWhatsAppProvider_Send_EmptySIDFallback(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"status": "queued",
+		})
+	}))
+	defer server.Close()
+
+	p := newTestWhatsAppProvider(t, server.URL)
+
+	result, err := p.Send(context.Background(), baseNotification(), baseUser())
+
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+	assert.Equal(t, "whatsapp-notif-001", result.ProviderMessageID)
+}
+
+// ─── URL path correctness ────────────────────────────────────────────────────
+
+func TestWhatsAppProvider_Send_URLContainsAccountSID(t *testing.T) {
+	var capturedPath string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		w.WriteHeader(http.StatusCreated)
+		w.Write(twilioSuccess("SM700"))
+	}))
+	defer server.Close()
+
+	p := newTestWhatsAppProvider(t, server.URL)
+
+	_, err := p.Send(context.Background(), baseNotification(), baseUser())
+
+	require.NoError(t, err)
+	assert.Equal(t, "/2010-04-01/Accounts/ACtest123/Messages.json", capturedPath)
+}
+
+// ─── Content template mode ignores body and media ────────────────────────────
+
+func TestWhatsAppProvider_Send_ContentTemplate_IgnoresBodyAndMedia(t *testing.T) {
+	var captured url.Values
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		captured, _ = url.ParseQuery(string(body))
+		w.WriteHeader(http.StatusCreated)
+		w.Write(twilioSuccess("SM800"))
+	}))
+	defer server.Close()
+
+	p := newTestWhatsAppProvider(t, server.URL)
+	notif := &notification.Notification{
+		NotificationID: "notif-tmpl",
+		Content: notification.Content{
+			Title:    "Should be ignored",
+			Body:     "This body should not appear",
+			MediaURL: "https://example.com/photo.png",
+			Data: map[string]interface{}{
+				"content_sid": "HXtmpl",
+			},
+		},
+	}
+
+	result, err := p.Send(context.Background(), notif, baseUser())
+
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+	assert.Equal(t, "HXtmpl", captured.Get("ContentSid"))
+	assert.Empty(t, captured.Get("Body"))
+	assert.Empty(t, captured.Get("MediaUrl"))
+}

--- a/ui/src/components/AppNotifications.tsx
+++ b/ui/src/components/AppNotifications.tsx
@@ -511,6 +511,11 @@ const AppNotifications: React.FC<AppNotificationsProps> = ({ apiKey, webhooks, o
     const [advDigestRuleId, setAdvDigestRuleId] = useState<string>('');
     const [advRichContent, setAdvRichContent] = useState<RichContentData>(emptyRichContent()); const [broadcastDigestRuleId, setBroadcastDigestRuleId] = useState<string>('');
 
+    // ── Free-form WhatsApp state ──
+    const [quickFreeformBody, setQuickFreeformBody] = useState('');
+    const [quickFreeformTitle, setQuickFreeformTitle] = useState('');
+    const isFreeformWhatsApp = quickTemplateId === 'freeform:whatsapp';
+
     // Filtered templates by channel
     const filteredTemplates = useMemo(() => (templates || []).filter(t => t.channel === formData.channel), [templates, formData.channel]);
 
@@ -815,14 +820,20 @@ const AppNotifications: React.FC<AppNotificationsProps> = ({ apiKey, webhooks, o
     }, [user]);
 
     const handleQuickSend = async () => {
-        const isTwilioCheck = isTwilioSelection(quickTemplateId);
-        const selTpl = isTwilioCheck ? undefined : templates.find(t => t.id === quickTemplateId);
+        const isFreeform = isFreeformWhatsApp;
+        const isTwilioCheck = !isFreeform && isTwilioSelection(quickTemplateId);
+        const selTpl = (isTwilioCheck || isFreeform) ? undefined : templates.find(t => t.id === quickTemplateId);
         const isWebhookLike = selTpl ? WEBHOOK_LIKE_CHANNELS.includes(selTpl.channel) : false;
-        if (!quickTemplateId || (!isWebhookLike && !quickTo)) return;
+        if (!quickTemplateId || (!isWebhookLike && !isFreeform && !quickTo)) return;
+        if (isFreeform && !quickTo) return;
+        if (isFreeform && !quickFreeformBody.trim()) {
+            toast.error('Message body is required for free-form WhatsApp messages.');
+            return;
+        }
 
         const isTwilio = isTwilioCheck;
-        const selectedTemplate = isTwilio ? undefined : templates.find(t => t.id === quickTemplateId);
-        const channel = isTwilio ? 'whatsapp' : (selectedTemplate?.channel || 'email');
+        const selectedTemplate = (isTwilio || isFreeform) ? undefined : templates.find(t => t.id === quickTemplateId);
+        const channel = (isTwilio || isFreeform) ? 'whatsapp' : (selectedTemplate?.channel || 'email');
         if (checkVerificationAndBlock(channel)) return;
 
         if (quickScheduledAt && quickScheduledAt < nowInTimezone(scheduleTimezone)) {
@@ -846,12 +857,16 @@ const AppNotifications: React.FC<AppNotificationsProps> = ({ apiKey, webhooks, o
                     content_sid: twilioTpl.sid,
                     content_variables: JSON.stringify(quickData || {}),
                 }
-                : (Object.keys(quickData).length > 0 ? quickData : undefined);
+                : isFreeform
+                    ? (quickMedia ? { media_url: quickMedia.url } : undefined)
+                    : (Object.keys(quickData).length > 0 ? quickData : undefined);
 
             await quickSendAPI.send(apiKey, {
                 to: isWebhookLike ? '' : quickTo,
-                template: isTwilio ? undefined : (quickSelectedTemplate?.name || quickTemplateId),
-                channel: isTwilio ? 'whatsapp' : undefined,
+                template: (isTwilio || isFreeform) ? undefined : (quickSelectedTemplate?.name || quickTemplateId),
+                channel: (isTwilio || isFreeform) ? 'whatsapp' : undefined,
+                subject: isFreeform && quickFreeformTitle ? quickFreeformTitle : undefined,
+                body: isFreeform ? quickFreeformBody : undefined,
                 data: {
                     ...sendData,
                     ...(!isRichContentEmpty(quickRichContent) ? richContentToPayload(quickRichContent) : {}),
@@ -881,6 +896,8 @@ const AppNotifications: React.FC<AppNotificationsProps> = ({ apiKey, webhooks, o
             setQuickScheduleEnabled(false);
             setQuickDigestRuleId('');
             setQuickWebhookUrl('');
+            setQuickFreeformBody('');
+            setQuickFreeformTitle('');
             if (quickMedia?.previewUrl) {
                 URL.revokeObjectURL(quickMedia.previewUrl);
             }
@@ -1258,6 +1275,10 @@ const AppNotifications: React.FC<AppNotificationsProps> = ({ apiKey, webhooks, o
                                                         ))}
                                                     </>
                                                 )}
+                                                <div className="px-2 py-1.5 text-xs font-semibold text-muted-foreground border-t mt-1 pt-1">WhatsApp Direct</div>
+                                                <SelectItem value="freeform:whatsapp">
+                                                    Free-form message (24h window)
+                                                </SelectItem>
                                             </SelectContent>
                                         </Select>
                                     </div>
@@ -1361,6 +1382,105 @@ const AppNotifications: React.FC<AppNotificationsProps> = ({ apiKey, webhooks, o
                                         )}
                                     </div>
                                 )}
+                                {/* Free-form WhatsApp message (24h customer service window) */}
+                                {isFreeformWhatsApp && (
+                                    <div className={`${SEND_FORM_SECTION_CLASS} p-4 space-y-3`}>
+                                        <div className="flex items-center justify-between">
+                                            <span className="text-sm font-medium flex items-center gap-2">
+                                                Free-form WhatsApp Message
+                                                <Badge variant="secondary" className="text-xs">24h window</Badge>
+                                            </span>
+                                        </div>
+                                        <p className="text-xs text-muted-foreground">
+                                            Send a direct message without a pre-approved template. Only works within 24 hours of the user&apos;s last incoming message.
+                                        </p>
+                                        <div className="space-y-1">
+                                            <Label className="text-xs">Title (optional, shown bold)</Label>
+                                            <Input
+                                                value={quickFreeformTitle}
+                                                onChange={(e) => setQuickFreeformTitle(e.target.value)}
+                                                placeholder="e.g. Order Update"
+                                                className="h-8 text-sm"
+                                            />
+                                        </div>
+                                        <div className="space-y-1">
+                                            <Label className="text-xs">Message Body</Label>
+                                            <textarea
+                                                className="flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                                                value={quickFreeformBody}
+                                                onChange={(e) => setQuickFreeformBody(e.target.value)}
+                                                placeholder="Type your WhatsApp message here..."
+                                            />
+                                        </div>
+                                    </div>
+                                )}
+                                {/* Media attachment for free-form WhatsApp or non-Twilio WhatsApp templates */}
+                                {(isFreeformWhatsApp || quickSelectedTemplate?.channel === 'whatsapp') && (
+                                    <div className="space-y-2 border-t border-border/50 pt-4 mt-2">
+                                        <Label className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Image Attachment (optional)</Label>
+                                        {!quickMedia && (
+                                            <label
+                                                htmlFor="quickMediaUploadFreeform"
+                                                className="flex flex-col items-center justify-center gap-2 rounded-lg border-2 border-dashed border-border bg-muted/30 p-5 cursor-pointer hover:bg-muted/50 transition-colors"
+                                            >
+                                                <UploadCloud className="h-7 w-7 text-muted-foreground" />
+                                                <span className="text-sm font-medium">Click to upload image</span>
+                                                <span className="text-xs text-muted-foreground">JPEG, PNG, GIF, WebP — max 16 MB</span>
+                                                <input
+                                                    id="quickMediaUploadFreeform"
+                                                    type="file"
+                                                    accept="image/jpeg,image/png,image/gif,image/webp"
+                                                    className="hidden"
+                                                    onChange={async (e) => {
+                                                        const file = e.target.files?.[0];
+                                                        if (!file) return;
+                                                        if (file.size > 16 * 1024 * 1024) {
+                                                            toast.error(`${file.name} is too large (max 16 MB)`);
+                                                            return;
+                                                        }
+                                                        const localUrl = URL.createObjectURL(file);
+                                                        try {
+                                                            toast.info(`Uploading ${file.name}...`);
+                                                            const result = await mediaAPI.upload(apiKey, file);
+                                                            setQuickMedia(prev => {
+                                                                if (prev?.previewUrl) URL.revokeObjectURL(prev.previewUrl);
+                                                                return { url: result.url, previewUrl: localUrl, type: file.type, name: file.name };
+                                                            });
+                                                            setQuickData(d => ({ ...d, media_url: result.url }));
+                                                            toast.success('Image uploaded');
+                                                        } catch (err) {
+                                                            URL.revokeObjectURL(localUrl);
+                                                            toast.error(`Upload failed for ${file.name}: ` + extractErrorMessage(err));
+                                                        }
+                                                    }}
+                                                />
+                                            </label>
+                                        )}
+                                        {quickMedia && (
+                                            <div className="flex items-center justify-between p-3 rounded-lg border border-border bg-muted/30">
+                                                <div className="flex items-center gap-3 min-w-0">
+                                                    <img src={quickMedia.previewUrl} alt={quickMedia.name} className="h-12 w-12 rounded object-cover border border-border" />
+                                                    <div className="min-w-0">
+                                                        <p className="text-sm font-medium truncate">{quickMedia.name}</p>
+                                                        <p className="text-xs text-muted-foreground truncate">{quickMedia.url}</p>
+                                                    </div>
+                                                </div>
+                                                <Button
+                                                    className="bg-red-400/10 hover:bg-red-400/20 text-red-500 border-red-200"
+                                                    variant="outline"
+                                                    size="sm"
+                                                    onClick={() => {
+                                                        URL.revokeObjectURL(quickMedia.previewUrl);
+                                                        setQuickMedia(null);
+                                                        setQuickData(d => { const next = { ...d }; delete next.media_url; return next; });
+                                                    }}
+                                                >
+                                                    <X className="h-3.5 w-3.5" />
+                                                </Button>
+                                            </div>
+                                        )}
+                                    </div>
+                                )}
                                 {quickSelectedTemplate?.channel === 'webhook' && (
                                     webhooks && Object.keys(webhooks).length > 0 ? (
                                         <div className="space-y-2 border-t border-border/50 pt-4 mt-2">
@@ -1383,85 +1503,6 @@ const AppNotifications: React.FC<AppNotificationsProps> = ({ apiKey, webhooks, o
                                             <p className="text-xs text-muted-foreground mt-1">Go to the <strong>Providers</strong> tab to add webhook endpoints.</p>
                                         </div>
                                     )
-                                )}
-                                {quickSelectedTemplate?.channel === 'whatsapp' && (
-                                    <div className="space-y-2 border-t border-border/50 pt-4 mt-2">
-                                        <Label className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Image Attachment (optional)</Label>
-                                        {!quickMedia && (
-                                            <label
-                                                htmlFor="quickMediaUpload"
-                                                className="flex flex-col items-center justify-center gap-2 rounded-lg border-2 border-dashed border-border bg-muted/30 p-5 cursor-pointer hover:bg-muted/50 transition-colors"
-                                            >
-                                                <UploadCloud className="h-7 w-7 text-muted-foreground" />
-                                                <span className="text-sm font-medium">Click to upload image</span>
-                                                <span className="text-xs text-muted-foreground">JPEG, PNG, GIF, WebP — max 16 MB</span>
-                                                <input
-                                                    id="quickMediaUpload"
-                                                    type="file"
-                                                    accept="image/jpeg,image/png,image/gif,image/webp"
-                                                    className="hidden"
-                                                    onChange={async (e) => {
-                                                        const file = e.target.files?.[0];
-                                                        if (!file) return;
-                                                        if (file.size > 16 * 1024 * 1024) {
-                                                            toast.error(`${file.name} is too large (max 16 MB)`);
-                                                            return;
-                                                        }
-
-                                                        const localUrl = URL.createObjectURL(file);
-                                                        try {
-                                                            toast.info(`Uploading ${file.name}...`);
-                                                            const result = await mediaAPI.upload(apiKey, file);
-                                                            setQuickMedia((prev) => {
-                                                                if (prev?.previewUrl) {
-                                                                    URL.revokeObjectURL(prev.previewUrl);
-                                                                }
-                                                                return {
-                                                                    url: result.url,
-                                                                    previewUrl: localUrl,
-                                                                    type: file.type,
-                                                                    name: file.name,
-                                                                };
-                                                            });
-                                                            setQuickData((d) => ({ ...d, media_url: result.url }));
-                                                            toast.success('Image uploaded');
-                                                        } catch (err) {
-                                                            URL.revokeObjectURL(localUrl);
-                                                            toast.error(`Upload failed for ${file.name}: ` + extractErrorMessage(err));
-                                                        }
-                                                    }}
-                                                />
-                                            </label>
-                                        )}
-
-                                        {quickMedia && (
-                                            <div className="flex items-center justify-between p-3 rounded-lg border border-border bg-muted/30">
-                                                <div className="flex items-center gap-3 min-w-0">
-                                                    <img src={quickMedia.previewUrl} alt={quickMedia.name} className="h-12 w-12 rounded object-cover border border-border" />
-                                                    <div className="min-w-0">
-                                                        <p className="text-sm font-medium truncate">{quickMedia.name}</p>
-                                                        <p className="text-xs text-muted-foreground truncate">{quickMedia.url}</p>
-                                                    </div>
-                                                </div>
-                                                <Button
-                                                    className="bg-red-400/10 hover:bg-red-400/20 text-red-500 border-red-200"
-                                                    variant="outline"
-                                                    size="sm"
-                                                    onClick={() => {
-                                                        URL.revokeObjectURL(quickMedia.previewUrl);
-                                                        setQuickMedia(null);
-                                                        setQuickData((d) => {
-                                                            const next = { ...d };
-                                                            delete next.media_url;
-                                                            return next;
-                                                        });
-                                                    }}
-                                                >
-                                                    <X className="h-3.5 w-3.5" />
-                                                </Button>
-                                            </div>
-                                        )}
-                                    </div>
                                 )}
                                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                                     <div className="space-y-2">

--- a/ui/src/pages/whatsapp/TwilioWhatsAppTemplates.tsx
+++ b/ui/src/pages/whatsapp/TwilioWhatsAppTemplates.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { twilioTemplatesAPI } from '../../services/api';
 import { useApiQuery } from '../../hooks/use-api-query';
 import { Card, CardHeader, CardTitle, CardContent } from '../../components/ui/card';
@@ -22,8 +22,20 @@ import {
     ChevronDown,
     ChevronUp,
     Copy,
+    Pencil,
+    CopyPlus,
 } from 'lucide-react';
 import type { TwilioContentTemplate } from '../../types';
+
+/** Extract {{N}} variable placeholders from a template body string. */
+function extractVariableKeys(body: string): string[] {
+    const matches = body.match(/\{\{\s*(\w+)\s*\}\}/g);
+    if (!matches) return [];
+    const keys = [...new Set(matches.map(m => m.replace(/[{}\s]/g, '')))];
+    const numeric = keys.filter(k => /^\d+$/.test(k)).sort((a, b) => Number(a) - Number(b));
+    const named = keys.filter(k => !/^\d+$/.test(k));
+    return [...numeric, ...named];
+}
 
 interface TwilioWhatsAppTemplatesProps {
     apiKey: string;
@@ -72,6 +84,18 @@ const TwilioWhatsAppTemplates: React.FC<TwilioWhatsAppTemplatesProps> = ({ apiKe
         language: 'en',
         body: '',
     });
+    // Example values for variable placeholders — required by Meta/WhatsApp for approval
+    const [newTemplateVarExamples, setNewTemplateVarExamples] = useState<Record<string, string>>({});
+
+    // Auto-extracted variable keys from the create/edit body
+    const newTemplateVarKeys = useMemo(() => extractVariableKeys(newTemplate.body), [newTemplate.body]);
+
+    // ── Edit mode for unsubmitted templates ──
+    const [editingSid, setEditingSid] = useState<string | null>(null);
+    const [editForm, setEditForm] = useState({ friendly_name: '', body: '' });
+    const [editVarExamples, setEditVarExamples] = useState<Record<string, string>>({});
+    const [saving, setSaving] = useState(false);
+    const editVarKeys = useMemo(() => extractVariableKeys(editForm.body), [editForm.body]);
 
     const { data: rawData, loading, refetch } = useApiQuery(
         () => twilioTemplatesAPI.list(apiKey),
@@ -89,24 +113,87 @@ const TwilioWhatsAppTemplates: React.FC<TwilioWhatsAppTemplatesProps> = ({ apiKe
             toast.error('Name and body text are required');
             return;
         }
+        // Validate that all detected variables have example values (Meta requires these)
+        const missingExamples = newTemplateVarKeys.filter(k => !newTemplateVarExamples[k]?.trim());
+        if (missingExamples.length > 0) {
+            toast.error(`Provide example values for: ${missingExamples.map(k => `{{${k}}}`).join(', ')}`);
+            return;
+        }
         setCreating(true);
         try {
+            const variables: Record<string, string> | undefined =
+                newTemplateVarKeys.length > 0
+                    ? Object.fromEntries(newTemplateVarKeys.map(k => [k, newTemplateVarExamples[k]?.trim() || '']))
+                    : undefined;
             await twilioTemplatesAPI.create(apiKey, {
                 friendly_name: newTemplate.friendly_name,
                 language: newTemplate.language,
                 types: {
                     'twilio/text': { body: newTemplate.body },
                 },
+                variables,
             });
             toast.success('Template created successfully');
             setShowCreate(false);
             setNewTemplate({ friendly_name: '', language: 'en', body: '' });
+            setNewTemplateVarExamples({});
             refetch();
         } catch (err: any) {
             toast.error('Failed to create template: ' + (err.response?.data?.error || err.message));
         } finally {
             setCreating(false);
         }
+    };
+
+    // ── Edit handler (unsubmitted templates only) ──
+    const startEdit = (tpl: TwilioContentTemplate) => {
+        setEditingSid(tpl.sid);
+        setEditForm({
+            friendly_name: tpl.friendly_name,
+            body: getBodyText(tpl),
+        });
+        setEditVarExamples(tpl.variables ? { ...tpl.variables } : {});
+    };
+
+    const handleSaveEdit = async () => {
+        if (!editingSid) return;
+        const missingExamples = editVarKeys.filter(k => !editVarExamples[k]?.trim());
+        if (missingExamples.length > 0) {
+            toast.error(`Provide example values for: ${missingExamples.map(k => `{{${k}}}`).join(', ')}`);
+            return;
+        }
+        setSaving(true);
+        try {
+            const variables: Record<string, string> | undefined =
+                editVarKeys.length > 0
+                    ? Object.fromEntries(editVarKeys.map(k => [k, editVarExamples[k]?.trim() || '']))
+                    : undefined;
+            await twilioTemplatesAPI.update(apiKey, editingSid, {
+                friendly_name: editForm.friendly_name,
+                types: { 'twilio/text': { body: editForm.body } },
+                variables,
+            });
+            toast.success('Template updated');
+            setEditingSid(null);
+            refetch();
+        } catch (err: any) {
+            toast.error('Update failed: ' + (err.response?.data?.error || err.message));
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    // ── Clone handler (for rejected templates — can't edit after submission) ──
+    const handleClone = (tpl: TwilioContentTemplate) => {
+        setNewTemplate({
+            friendly_name: tpl.friendly_name + ' (copy)',
+            language: tpl.language,
+            body: getBodyText(tpl),
+        });
+        setNewTemplateVarExamples(tpl.variables ? { ...tpl.variables } : {});
+        setShowCreate(true);
+        // Scroll to create form
+        window.scrollTo({ top: 0, behavior: 'smooth' });
     };
 
     const handleDelete = async (sid: string, name: string) => {
@@ -230,6 +317,28 @@ const TwilioWhatsAppTemplates: React.FC<TwilioWhatsAppTemplatesProps> = ({ apiKe
                                 Use {'{{1}}'}, {'{{2}}'}, etc. for variables. After creating, submit for WhatsApp approval.
                             </p>
                         </div>
+                        {newTemplateVarKeys.length > 0 && (
+                            <div className="space-y-3 p-3 rounded-md border border-dashed border-yellow-300 dark:border-yellow-700 bg-yellow-50/50 dark:bg-yellow-950/30">
+                                <p className="text-xs font-medium text-yellow-800 dark:text-yellow-200">
+                                    WhatsApp requires example values for each variable to approve the template.
+                                </p>
+                                <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                                    {newTemplateVarKeys.map(k => (
+                                        <div key={k} className="space-y-1">
+                                            <Label className="text-xs">
+                                                <code className="bg-muted px-1 rounded mr-1">{`{{${k}}}`}</code> example
+                                            </Label>
+                                            <Input
+                                                value={newTemplateVarExamples[k] || ''}
+                                                onChange={(e) => setNewTemplateVarExamples(prev => ({ ...prev, [k]: e.target.value }))}
+                                                placeholder={`e.g. ${k === '1' ? 'John' : k === '2' ? '12345' : 'sample_value'}`}
+                                                className="h-8 text-sm"
+                                            />
+                                        </div>
+                                    ))}
+                                </div>
+                            </div>
+                        )}
                         <div className="flex gap-2">
                             <Button onClick={handleCreate} disabled={creating}>
                                 {creating ? <Spinner className="h-4 w-4 mr-1" /> : null}
@@ -343,120 +452,189 @@ const TwilioWhatsAppTemplates: React.FC<TwilioWhatsAppTemplatesProps> = ({ apiKe
                                     </div>
                                 </CardHeader>
                                 <CardContent className="pt-2 flex-1 flex flex-col">
-                                    <p className="text-xs text-muted-foreground line-clamp-3 flex-1">
-                                        {body}
-                                    </p>
-
-                                    {/* Expanded details */}
-                                    {isExpanded && (
-                                        <div className="mt-3 space-y-3 border-t pt-3">
-                                            <div className="flex items-center gap-1 text-xs text-muted-foreground">
-                                                <span className="font-medium">SID:</span>
-                                                <code className="bg-muted px-1 rounded text-[11px]">{tpl.sid}</code>
-                                                <Button variant="ghost" size="sm" className="h-5 w-5 p-0" onClick={() => copySid(tpl.sid)}>
-                                                    <Copy className="h-3 w-3" />
-                                                </Button>
+                                    {/* Inline edit form (unsubmitted only) */}
+                                    {editingSid === tpl.sid ? (
+                                        <div className="space-y-3">
+                                            <div className="space-y-1">
+                                                <Label className="text-xs">Friendly Name</Label>
+                                                <Input
+                                                    value={editForm.friendly_name}
+                                                    onChange={(e) => setEditForm(f => ({ ...f, friendly_name: e.target.value }))}
+                                                    className="h-8 text-sm"
+                                                />
                                             </div>
-                                            {tpl.variables && Object.keys(tpl.variables).length > 0 && (
-                                                <div className="text-xs">
-                                                    <span className="font-medium text-muted-foreground">Variables:</span>
-                                                    <div className="mt-1 space-y-1">
-                                                        {Object.entries(tpl.variables).map(([key, desc]) => (
-                                                            <div key={key} className="flex gap-2">
-                                                                <code className="bg-muted px-1 rounded text-[11px]">{`{{${key}}}`}</code>
-                                                                <span className="text-muted-foreground">{desc}</span>
-                                                            </div>
-                                                        ))}
-                                                    </div>
-                                                </div>
-                                            )}
-                                            {tpl.approval_requests?.rejection_reason && (
-                                                <div className="text-xs p-2 rounded bg-red-50 dark:bg-red-950 text-red-700 dark:text-red-300">
-                                                    <span className="font-medium">Rejection reason:</span> {tpl.approval_requests.rejection_reason}
-                                                </div>
-                                            )}
-
-                                            {/* Preview section */}
-                                            {previewData?.sid === tpl.sid && (
-                                                <div className="space-y-2 flex flex-col items-center">
-                                                    <span className="text-xs font-medium text-muted-foreground self-start">WhatsApp Preview:</span>
-                                                    <WhatsAppPreview
-                                                        template={tpl}
-                                                        variables={previewVars}
-                                                        header={tpl.friendly_name}
-                                                        compact
-                                                    />
-                                                </div>
-                                            )}
-
-                                            {/* Variable inputs for preview */}
-                                            {tpl.variables && Object.keys(tpl.variables).length > 0 && (
-                                                <div className="space-y-2">
-                                                    <span className="text-xs font-medium text-muted-foreground">Test variables:</span>
-                                                    {Object.entries(tpl.variables).map(([key]) => (
-                                                        <Input
-                                                            key={key}
-                                                            className="h-7 text-xs"
-                                                            placeholder={`{{${key}}}`}
-                                                            value={previewVars[key] || ''}
-                                                            onChange={(e) => setPreviewVars({ ...previewVars, [key]: e.target.value })}
-                                                        />
+                                            <div className="space-y-1">
+                                                <Label className="text-xs">Body Text</Label>
+                                                <textarea
+                                                    className="flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-xs"
+                                                    value={editForm.body}
+                                                    onChange={(e) => setEditForm(f => ({ ...f, body: e.target.value }))}
+                                                />
+                                            </div>
+                                            {editVarKeys.length > 0 && (
+                                                <div className="space-y-2 p-2 rounded border border-dashed border-yellow-300 dark:border-yellow-700 bg-yellow-50/50 dark:bg-yellow-950/30">
+                                                    <p className="text-[11px] font-medium text-yellow-800 dark:text-yellow-200">Example values (required for approval)</p>
+                                                    {editVarKeys.map(k => (
+                                                        <div key={k} className="flex items-center gap-2">
+                                                            <code className="text-[11px] bg-muted px-1 rounded shrink-0">{`{{${k}}}`}</code>
+                                                            <Input
+                                                                value={editVarExamples[k] || ''}
+                                                                onChange={(e) => setEditVarExamples(prev => ({ ...prev, [k]: e.target.value }))}
+                                                                placeholder="example value"
+                                                                className="h-7 text-xs"
+                                                            />
+                                                        </div>
                                                     ))}
                                                 </div>
                                             )}
+                                            <div className="flex gap-2">
+                                                <Button size="sm" className="h-7 text-xs" onClick={handleSaveEdit} disabled={saving}>
+                                                    {saving ? <Spinner className="h-3 w-3 mr-1" /> : null}
+                                                    Save
+                                                </Button>
+                                                <Button variant="outline" size="sm" className="h-7 text-xs" onClick={() => setEditingSid(null)}>
+                                                    Cancel
+                                                </Button>
+                                            </div>
                                         </div>
-                                    )}
+                                    ) : (
+                                        <>
+                                            <p className="text-xs text-muted-foreground line-clamp-3 flex-1">
+                                                {body}
+                                            </p>
 
-                                    {/* Actions */}
-                                    <div className="flex flex-wrap gap-1 mt-3 pt-2 border-t">
-                                        {status === 'unsubmitted' && (
-                                            <Button
-                                                variant="ghost"
-                                                size="sm"
-                                                className="text-xs h-7"
-                                                onClick={() => setApprovalForm({
-                                                    sid: tpl.sid,
-                                                    name: tpl.friendly_name.toLowerCase().replace(/[^a-z0-9]+/g, '_'),
-                                                    category: 'UTILITY',
-                                                })}
-                                            >
-                                                <Send className="h-3 w-3 mr-1" /> Submit Approval
-                                            </Button>
-                                        )}
-                                        <Button variant="ghost" size="sm" className="text-xs h-7" onClick={() => handleSync(tpl.sid)}>
-                                            <RefreshCw className="h-3 w-3 mr-1" /> Sync
-                                        </Button>
-                                        {isExpanded && (
-                                            <Button
-                                                variant="ghost"
-                                                size="sm"
-                                                className="text-xs h-7"
-                                                onClick={() => handlePreview(tpl)}
-                                                disabled={previewLoading}
-                                            >
-                                                {previewLoading ? <Spinner className="h-3 w-3 mr-1" /> : <Eye className="h-3 w-3 mr-1" />}
-                                                Preview
-                                            </Button>
-                                        )}
-                                        {status === 'approved' && (
-                                            <Button
-                                                variant="ghost"
-                                                size="sm"
-                                                className="text-xs h-7"
-                                                onClick={() => copySid(tpl.sid)}
-                                            >
-                                                <Copy className="h-3 w-3 mr-1" /> Copy SID
-                                            </Button>
-                                        )}
-                                        <Button
-                                            variant="ghost"
-                                            size="sm"
-                                            className="text-xs h-7 text-destructive"
-                                            onClick={() => handleDelete(tpl.sid, tpl.friendly_name)}
-                                        >
-                                            <Trash2 className="h-3 w-3 mr-1" /> Delete
-                                        </Button>
-                                    </div>
+                                            {/* Expanded details */}
+                                            {isExpanded && (
+                                                <div className="mt-3 space-y-3 border-t pt-3">
+                                                    <div className="flex items-center gap-1 text-xs text-muted-foreground">
+                                                        <span className="font-medium">SID:</span>
+                                                        <code className="bg-muted px-1 rounded text-[11px]">{tpl.sid}</code>
+                                                        <Button variant="ghost" size="sm" className="h-5 w-5 p-0" onClick={() => copySid(tpl.sid)}>
+                                                            <Copy className="h-3 w-3" />
+                                                        </Button>
+                                                    </div>
+                                                    {tpl.variables && Object.keys(tpl.variables).length > 0 && (
+                                                        <div className="text-xs">
+                                                            <span className="font-medium text-muted-foreground">Variables:</span>
+                                                            <div className="mt-1 space-y-1">
+                                                                {Object.entries(tpl.variables).map(([key, desc]) => (
+                                                                    <div key={key} className="flex gap-2">
+                                                                        <code className="bg-muted px-1 rounded text-[11px]">{`{{${key}}}`}</code>
+                                                                        <span className="text-muted-foreground">{desc}</span>
+                                                                    </div>
+                                                                ))}
+                                                            </div>
+                                                        </div>
+                                                    )}
+                                                    {tpl.approval_requests?.rejection_reason && (
+                                                        <div className="text-xs p-2 rounded bg-red-50 dark:bg-red-950 text-red-700 dark:text-red-300">
+                                                            <span className="font-medium">Rejection reason:</span> {tpl.approval_requests.rejection_reason}
+                                                        </div>
+                                                    )}
+
+                                                    {/* Preview section */}
+                                                    {previewData?.sid === tpl.sid && (
+                                                        <div className="space-y-2 flex flex-col items-center">
+                                                            <span className="text-xs font-medium text-muted-foreground self-start">WhatsApp Preview:</span>
+                                                            <WhatsAppPreview
+                                                                template={tpl}
+                                                                variables={previewVars}
+                                                                header={tpl.friendly_name}
+                                                                compact
+                                                            />
+                                                        </div>
+                                                    )}
+
+                                                    {/* Variable inputs for preview */}
+                                                    {tpl.variables && Object.keys(tpl.variables).length > 0 && (
+                                                        <div className="space-y-2">
+                                                            <span className="text-xs font-medium text-muted-foreground">Test variables:</span>
+                                                            {Object.entries(tpl.variables).map(([key]) => (
+                                                                <Input
+                                                                    key={key}
+                                                                    className="h-7 text-xs"
+                                                                    placeholder={`{{${key}}}`}
+                                                                    value={previewVars[key] || ''}
+                                                                    onChange={(e) => setPreviewVars({ ...previewVars, [key]: e.target.value })}
+                                                                />
+                                                            ))}
+                                                        </div>
+                                                    )}
+                                                </div>
+                                            )}
+
+                                            {/* Actions */}
+                                            <div className="flex flex-wrap gap-1 mt-3 pt-2 border-t">
+                                                {status === 'unsubmitted' && (
+                                                    <Button
+                                                        variant="ghost"
+                                                        size="sm"
+                                                        className="text-xs h-7"
+                                                        onClick={() => setApprovalForm({
+                                                            sid: tpl.sid,
+                                                            name: tpl.friendly_name.toLowerCase().replace(/[^a-z0-9]+/g, '_'),
+                                                            category: 'UTILITY',
+                                                        })}
+                                                    >
+                                                        <Send className="h-3 w-3 mr-1" /> Submit Approval
+                                                    </Button>
+                                                )}
+                                                {status === 'unsubmitted' && (
+                                                    <Button
+                                                        variant="ghost"
+                                                        size="sm"
+                                                        className="text-xs h-7"
+                                                        onClick={() => startEdit(tpl)}
+                                                    >
+                                                        <Pencil className="h-3 w-3 mr-1" /> Edit
+                                                    </Button>
+                                                )}
+                                                {status === 'rejected' && (
+                                                    <Button
+                                                        variant="ghost"
+                                                        size="sm"
+                                                        className="text-xs h-7"
+                                                        onClick={() => handleClone(tpl)}
+                                                    >
+                                                        <CopyPlus className="h-3 w-3 mr-1" /> Clone &amp; Fix
+                                                    </Button>
+                                                )}
+                                                <Button variant="ghost" size="sm" className="text-xs h-7" onClick={() => handleSync(tpl.sid)}>
+                                                    <RefreshCw className="h-3 w-3 mr-1" /> Sync
+                                                </Button>
+                                                {isExpanded && (
+                                                    <Button
+                                                        variant="ghost"
+                                                        size="sm"
+                                                        className="text-xs h-7"
+                                                        onClick={() => handlePreview(tpl)}
+                                                        disabled={previewLoading}
+                                                    >
+                                                        {previewLoading ? <Spinner className="h-3 w-3 mr-1" /> : <Eye className="h-3 w-3 mr-1" />}
+                                                        Preview
+                                                    </Button>
+                                                )}
+                                                {status === 'approved' && (
+                                                    <Button
+                                                        variant="ghost"
+                                                        size="sm"
+                                                        className="text-xs h-7"
+                                                        onClick={() => copySid(tpl.sid)}
+                                                    >
+                                                        <Copy className="h-3 w-3 mr-1" /> Copy SID
+                                                    </Button>
+                                                )}
+                                                <Button
+                                                    variant="ghost"
+                                                    size="sm"
+                                                    className="text-xs h-7 text-destructive"
+                                                    onClick={() => handleDelete(tpl.sid, tpl.friendly_name)}
+                                                >
+                                                    <Trash2 className="h-3 w-3 mr-1" /> Delete
+                                                </Button>
+                                            </div>
+                                        </>
+                                    )}
                                 </CardContent>
                             </Card>
                         );


### PR DESCRIPTION
- Fix content_variables type assertion (handle JSON string from UI)
- Add variable example values to template creation (required by Meta)
- Add inline edit for unsubmitted templates
- Add Clone & Fix action for rejected templates
- Add free-form WhatsApp message option in Quick Send (24h window)
- Consolidate media upload for all WhatsApp send modes
- Auto-extract {{N}} variables from template body
- Add comprehensive WhatsApp provider unit tests (33 cases)