### PR TITLE
fix: Notification.Validate() now accepts all webhook-like channels (discord, slack, teams)

### DIFF
--- a/internal/domain/notification/models.go
+++ b/internal/domain/notification/models.go
@@ -431,10 +431,10 @@ func (n *Notification) Validate() error {
 		return ErrInvalidAppID
 	}
 	if n.UserID == "" {
-		if n.Channel != ChannelWebhook {
+		if !isWebhookLikeChannel(n.Channel) {
 			return ErrInvalidUserID
 		}
-		// For webhook, check if we have the URL in metadata
+		// For webhook-like channels, check if we have the URL in metadata
 		hasURL := false
 		if n.Metadata != nil {
 			if _, ok := n.Metadata["webhook_url"]; ok {
@@ -442,7 +442,7 @@ func (n *Notification) Validate() error {
 			}
 		}
 
-		// If no explicit URL, we must have a TemplateID which can resolve via WebhookTarget
+		// If no explicit URL, we must have a TemplateID which can resolve via provider config
 		if !hasURL && n.TemplateID == "" {
 			return ErrInvalidUserID
 		}

--- a/internal/domain/notification/models_test.go
+++ b/internal/domain/notification/models_test.go
@@ -167,6 +167,31 @@ func TestNotificationValidate(t *testing.T) {
 			ErrInvalidUserID,
 		},
 		{
+			"Discord channel with empty UserID and TemplateID is valid",
+			&Notification{NotificationID: "notif-123", AppID: "app-123", Channel: ChannelDiscord, TemplateID: "tmpl-1", Priority: PriorityNormal, Status: StatusPending, Content: Content{Title: "Test"}},
+			nil,
+		},
+		{
+			"Slack channel with empty UserID and TemplateID is valid",
+			&Notification{NotificationID: "notif-123", AppID: "app-123", Channel: ChannelSlack, TemplateID: "tmpl-1", Priority: PriorityNormal, Status: StatusPending, Content: Content{Title: "Test"}},
+			nil,
+		},
+		{
+			"Teams channel with empty UserID and TemplateID is valid",
+			&Notification{NotificationID: "notif-123", AppID: "app-123", Channel: ChannelTeams, TemplateID: "tmpl-1", Priority: PriorityNormal, Status: StatusPending, Content: Content{Title: "Test"}},
+			nil,
+		},
+		{
+			"Discord channel with empty UserID and no TemplateID requires webhook_url",
+			&Notification{NotificationID: "notif-123", AppID: "app-123", Channel: ChannelDiscord, Priority: PriorityNormal, Status: StatusPending, Content: Content{Title: "Test"}},
+			ErrInvalidUserID,
+		},
+		{
+			"Webhook-like channel with metadata webhook_url is valid",
+			&Notification{NotificationID: "notif-123", AppID: "app-123", Channel: ChannelDiscord, Priority: PriorityNormal, Status: StatusPending, Content: Content{Title: "Test"}, Metadata: map[string]interface{}{"webhook_url": "https://discord.com/api/webhooks/123/abc"}},
+			nil,
+		},
+		{
 			"Invalid Channel",
 			&Notification{NotificationID: "notif-123", AppID: "app-123", UserID: "user-123", Channel: Channel("invalid"), Priority: PriorityNormal, Status: StatusPending, Content: Content{Title: "Test"}},
 			ErrInvalidChannel,


### PR DESCRIPTION

The Notification entity Validate() only exempted ChannelWebhook from requiring a UserID. Discord, Slack, and Teams channels — which are also webhook-like and deliver to a URL endpoint, not a user — were incorrectly rejected with 'invalid user ID'.

Changed the check from n.Channel != ChannelWebhook to !isWebhookLikeChannel(n.Channel), consistent with SendRequest.Validate() and the quick-send/notification service layers.

Added 5 unit tests covering discord/slack/teams with TemplateID, without TemplateID, and with metadata webhook_url.