### PR TITLE
feat: MediaURL bulk send support + comprehensive NotificationService unit tests

### DIFF
--- a/internal/domain/notification/models.go
+++ b/internal/domain/notification/models.go
@@ -457,7 +457,8 @@ func (n *Notification) Validate() error {
 		return ErrInvalidStatus
 	}
 	hasContentSid := n.Content.Data != nil && n.Content.Data["content_sid"] != nil
-	if n.TemplateID == "" && n.Content.Title == "" && n.Content.Body == "" && !hasContentSid {
+	hasMedia := n.Content.MediaURL != "" || (n.Content.Data != nil && n.Content.Data["media_url"] != nil)
+	if n.TemplateID == "" && n.Content.Title == "" && n.Content.Body == "" && !hasContentSid && !hasMedia {
 		return ErrEmptyContent
 	}
 	if err := n.Content.Validate(); err != nil {
@@ -561,14 +562,15 @@ type BulkSendRequest struct {
 	UserIDs       []string               `json:"user_ids" validate:"required,min=1"`
 	Channel       Channel                `json:"channel" validate:"required"`
 	Priority      Priority               `json:"priority" validate:"required"`
-	Title         string                 `json:"title" validate:"required"`
-	Body          string                 `json:"body" validate:"required"`
+	Title         string                 `json:"title,omitempty"`
+	Body          string                 `json:"body,omitempty"`
 	Data          map[string]interface{} `json:"data,omitempty"`
 	TemplateID    string                 `json:"template_id,omitempty"`
 	Category      string                 `json:"category,omitempty"`
 	ScheduledAt   *time.Time             `json:"scheduled_at,omitempty"`
 	Recurrence    *Recurrence            `json:"recurrence,omitempty"`
 	Metadata      map[string]interface{} `json:"metadata,omitempty"` // Digest: {"digest_key": "rule_key"}
+	MediaURL      string                 `json:"media_url,omitempty"`
 }
 
 // Validate validates the bulk send request
@@ -586,7 +588,8 @@ func (r *BulkSendRequest) Validate() error {
 		return ErrInvalidPriority
 	}
 	hasContentSid := r.Data != nil && r.Data["content_sid"] != nil
-	if r.TemplateID == "" && (r.Title == "" || r.Body == "") && !hasContentSid {
+	hasMedia := r.MediaURL != "" || (r.Data != nil && r.Data["media_url"] != nil)
+	if r.TemplateID == "" && (r.Title == "" || r.Body == "") && !hasContentSid && !hasMedia {
 		return ErrEmptyContent
 	}
 	if r.ScheduledAt != nil && r.ScheduledAt.Before(time.Now()) {

--- a/internal/interfaces/http/dto/notification_dto.go
+++ b/internal/interfaces/http/dto/notification_dto.go
@@ -73,13 +73,14 @@ type BulkSendNotificationRequest struct {
 	UserIDs     []string               `json:"user_ids" validate:"required,min=1"`
 	Channel     string                 `json:"channel" validate:"required,oneof=push email sms webhook in_app whatsapp"`
 	Priority    string                 `json:"priority" validate:"required,oneof=low normal high critical"`
-	Title       string                 `json:"title" validate:"required"`
-	Body        string                 `json:"body" validate:"required"`
+	Title       string                 `json:"title,omitempty"`
+	Body        string                 `json:"body,omitempty"`
 	Data        map[string]interface{} `json:"data,omitempty"`
 	TemplateID  string                 `json:"template_id,omitempty"`
 	Category    string                 `json:"category,omitempty"`
 	ScheduledAt *time.Time             `json:"scheduled_at,omitempty"`
 	Metadata    map[string]interface{} `json:"metadata,omitempty"` // Digest: {"digest_key": "rule_key"}
+	MediaURL    string                 `json:"media_url,omitempty" validate:"omitempty,url"`
 }
 
 // ToBulkSendRequest converts DTO to domain BulkSendRequest
@@ -96,6 +97,7 @@ func (r *BulkSendNotificationRequest) ToBulkSendRequest(appID string) notificati
 		Category:    r.Category,
 		ScheduledAt: r.ScheduledAt,
 		Metadata:    r.Metadata,
+		MediaURL:    r.MediaURL,
 	}
 }
 

--- a/internal/usecases/notification_service.go
+++ b/internal/usecases/notification_service.go
@@ -516,9 +516,10 @@ func (s *NotificationService) SendBulk(ctx context.Context, req notification.Bul
 			Priority:       req.Priority,
 			Status:         notification.StatusPending,
 			Content: notification.Content{
-				Title: req.Title,
-				Body:  req.Body,
-				Data:  req.Data,
+				Title:    req.Title,
+				Body:     req.Body,
+				Data:     req.Data,
+				MediaURL: req.MediaURL,
 			},
 			Category:    req.Category,
 			TemplateID:  req.TemplateID,
@@ -526,6 +527,13 @@ func (s *NotificationService) SendBulk(ctx context.Context, req notification.Bul
 			RetryCount:  0,
 			CreatedAt:   time.Now(),
 			UpdatedAt:   time.Now(),
+		}
+
+		// Promote data.media_url → Content.MediaURL when not set explicitly
+		if notif.Content.MediaURL == "" {
+			if mu, ok := req.Data["media_url"].(string); ok && mu != "" {
+				notif.Content.MediaURL = mu
+			}
 		}
 		if req.Metadata != nil {
 			notif.Metadata = make(map[string]interface{})

--- a/internal/usecases/notification_service_methods_test.go
+++ b/internal/usecases/notification_service_methods_test.go
@@ -1,0 +1,1027 @@
+package usecases
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/the-monkeys/freerangenotify/internal/domain/application"
+	"github.com/the-monkeys/freerangenotify/internal/domain/notification"
+	"github.com/the-monkeys/freerangenotify/internal/domain/user"
+	notifqueue "github.com/the-monkeys/freerangenotify/internal/infrastructure/queue"
+	"go.uber.org/zap"
+)
+
+// ─── Enhanced mocks for method-level testing ──────────────────────────────
+
+// fullMockNotifRepo provides configurable behavior for all repo methods.
+type fullMockNotifRepo struct {
+	mockNotificationRepo
+	notifications     map[string]*notification.Notification
+	createErr         error
+	updateStatusErr   error
+	updateErr         error
+	bulkUpdateErr     error
+	bulkArchiveErr    error
+	markAllReadErr    error
+	markAllReadCount  int
+	updateSnoozeErr   error
+	incrementRetryErr error
+	listResult        []*notification.Notification
+	listErr           error
+	countResult       int64
+	countErr          error
+	snoozedDueResult  []*notification.Notification
+
+	// Track calls
+	statusUpdates       map[string]notification.Status
+	bulkStatusIDs       []string
+	bulkStatusTarget    notification.Status
+	bulkArchiveIDs      []string
+	snoozeUpdates       map[string]notification.Status
+	incrementedRetryIDs []string
+}
+
+func newFullMockNotifRepo() *fullMockNotifRepo {
+	return &fullMockNotifRepo{
+		notifications: make(map[string]*notification.Notification),
+		statusUpdates: make(map[string]notification.Status),
+		snoozeUpdates: make(map[string]notification.Status),
+	}
+}
+
+func (m *fullMockNotifRepo) Create(ctx context.Context, n *notification.Notification) error {
+	if m.createErr != nil {
+		return m.createErr
+	}
+	m.created = append(m.created, n)
+	m.notifications[n.NotificationID] = n
+	return nil
+}
+
+func (m *fullMockNotifRepo) GetByID(ctx context.Context, id string) (*notification.Notification, error) {
+	if n, ok := m.notifications[id]; ok {
+		return n, nil
+	}
+	return nil, fmt.Errorf("not found")
+}
+
+func (m *fullMockNotifRepo) UpdateStatus(ctx context.Context, id string, status notification.Status) error {
+	if m.updateStatusErr != nil {
+		return m.updateStatusErr
+	}
+	m.statusUpdates[id] = status
+	return nil
+}
+
+func (m *fullMockNotifRepo) Update(ctx context.Context, n *notification.Notification) error {
+	if m.updateErr != nil {
+		return m.updateErr
+	}
+	m.notifications[n.NotificationID] = n
+	return nil
+}
+
+func (m *fullMockNotifRepo) BulkUpdateStatus(ctx context.Context, ids []string, status notification.Status) error {
+	if m.bulkUpdateErr != nil {
+		return m.bulkUpdateErr
+	}
+	m.bulkStatusIDs = ids
+	m.bulkStatusTarget = status
+	return nil
+}
+
+func (m *fullMockNotifRepo) BulkArchive(ctx context.Context, ids []string, at time.Time) error {
+	if m.bulkArchiveErr != nil {
+		return m.bulkArchiveErr
+	}
+	m.bulkArchiveIDs = ids
+	return nil
+}
+
+func (m *fullMockNotifRepo) MarkAllRead(ctx context.Context, userID, appID, category string) (int, error) {
+	if m.markAllReadErr != nil {
+		return 0, m.markAllReadErr
+	}
+	return m.markAllReadCount, nil
+}
+
+func (m *fullMockNotifRepo) UpdateSnooze(ctx context.Context, id string, status notification.Status, t *time.Time) error {
+	if m.updateSnoozeErr != nil {
+		return m.updateSnoozeErr
+	}
+	m.snoozeUpdates[id] = status
+	return nil
+}
+
+func (m *fullMockNotifRepo) IncrementRetryCount(ctx context.Context, id, errorMessage string) error {
+	if m.incrementRetryErr != nil {
+		return m.incrementRetryErr
+	}
+	m.incrementedRetryIDs = append(m.incrementedRetryIDs, id)
+	return nil
+}
+
+func (m *fullMockNotifRepo) List(ctx context.Context, f *notification.NotificationFilter) ([]*notification.Notification, error) {
+	if m.listErr != nil {
+		return nil, m.listErr
+	}
+	return m.listResult, nil
+}
+
+func (m *fullMockNotifRepo) Count(ctx context.Context, f *notification.NotificationFilter) (int64, error) {
+	if m.countErr != nil {
+		return 0, m.countErr
+	}
+	return m.countResult, nil
+}
+
+func (m *fullMockNotifRepo) ListSnoozedDue(ctx context.Context, now time.Time) ([]*notification.Notification, error) {
+	return m.snoozedDueResult, nil
+}
+
+// fullMockQueue tracks all queue operations.
+type fullMockQueue struct {
+	mockQueue
+	enqueueErr         error
+	enqueuePriorityErr error
+	enqueuedItems      []notifqueue.NotificationQueueItem
+	priorityItems      []notifqueue.NotificationQueueItem
+	removedIDs         []string
+}
+
+func (m *fullMockQueue) Enqueue(ctx context.Context, item notifqueue.NotificationQueueItem) error {
+	if m.enqueueErr != nil {
+		return m.enqueueErr
+	}
+	m.enqueuedItems = append(m.enqueuedItems, item)
+	return nil
+}
+
+func (m *fullMockQueue) EnqueuePriority(ctx context.Context, item notifqueue.NotificationQueueItem) error {
+	if m.enqueuePriorityErr != nil {
+		return m.enqueuePriorityErr
+	}
+	m.priorityItems = append(m.priorityItems, item)
+	return nil
+}
+
+func (m *fullMockQueue) RemoveScheduledByID(ctx context.Context, ids []string) error {
+	m.removedIDs = append(m.removedIDs, ids...)
+	return nil
+}
+
+// newMethodTestService creates a service suitable for method-level tests
+// that don't go through the full Send() path.
+func newMethodTestService(
+	nrepo *fullMockNotifRepo,
+	q *fullMockQueue,
+) *NotificationService {
+	if nrepo == nil {
+		nrepo = newFullMockNotifRepo()
+	}
+	if q == nil {
+		q = &fullMockQueue{}
+	}
+	return NewNotificationService(
+		nrepo,
+		&mockUserRepo{users: map[string]*user.User{}},
+		&mockAppRepoSend{apps: defaultApps()},
+		&mockTemplateRepoNSC{},
+		q,
+		zap.NewNop(),
+		NotificationServiceConfig{MaxRetries: 3},
+		nil,
+		&mockLimiterSend{allowed: true},
+	).(*NotificationService)
+}
+
+// helper to seed a notification in the mock repo
+func seedNotification(repo *fullMockNotifRepo, id, appID, userID string, status notification.Status) *notification.Notification {
+	n := &notification.Notification{
+		NotificationID: id,
+		AppID:          appID,
+		UserID:         userID,
+		Channel:        notification.ChannelEmail,
+		Priority:       notification.PriorityNormal,
+		Status:         status,
+		Content:        notification.Content{Title: "Test", Body: "Body"},
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	}
+	repo.notifications[id] = n
+	return n
+}
+
+// ─── Get ──────────────────────────────────────────────────────────────────
+
+func TestNotificationService_Get(t *testing.T) {
+	t.Run("found and app matches", func(t *testing.T) {
+		repo := newFullMockNotifRepo()
+		seedNotification(repo, "n1", "app-1", "user-1", notification.StatusQueued)
+		svc := newMethodTestService(repo, nil)
+
+		n, err := svc.Get(context.Background(), "n1", "app-1")
+		require.NoError(t, err)
+		assert.Equal(t, "n1", n.NotificationID)
+	})
+
+	t.Run("not found returns error", func(t *testing.T) {
+		svc := newMethodTestService(nil, nil)
+
+		_, err := svc.Get(context.Background(), "missing", "app-1")
+		require.Error(t, err)
+	})
+
+	t.Run("wrong app returns error", func(t *testing.T) {
+		repo := newFullMockNotifRepo()
+		seedNotification(repo, "n1", "app-1", "user-1", notification.StatusQueued)
+		svc := newMethodTestService(repo, nil)
+
+		_, err := svc.Get(context.Background(), "n1", "app-OTHER")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "notification not found")
+	})
+}
+
+// ─── List ─────────────────────────────────────────────────────────────────
+
+func TestNotificationService_List(t *testing.T) {
+	t.Run("returns repo results", func(t *testing.T) {
+		repo := newFullMockNotifRepo()
+		repo.listResult = []*notification.Notification{
+			{NotificationID: "n1"},
+			{NotificationID: "n2"},
+		}
+		svc := newMethodTestService(repo, nil)
+
+		results, err := svc.List(context.Background(), notification.NotificationFilter{
+			AppID: "app-1", Page: 1, PageSize: 50,
+		})
+		require.NoError(t, err)
+		assert.Len(t, results, 2)
+	})
+
+	t.Run("invalid filter returns error", func(t *testing.T) {
+		svc := newMethodTestService(nil, nil)
+
+		_, err := svc.List(context.Background(), notification.NotificationFilter{
+			Channel: notification.Channel("bogus"),
+		})
+		require.Error(t, err)
+	})
+}
+
+// ─── Count ────────────────────────────────────────────────────────────────
+
+func TestNotificationService_Count(t *testing.T) {
+	t.Run("returns repo count", func(t *testing.T) {
+		repo := newFullMockNotifRepo()
+		repo.countResult = 42
+		svc := newMethodTestService(repo, nil)
+
+		count, err := svc.Count(context.Background(), notification.NotificationFilter{
+			AppID: "app-1", Page: 1, PageSize: 50,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, int64(42), count)
+	})
+
+	t.Run("invalid filter returns error", func(t *testing.T) {
+		svc := newMethodTestService(nil, nil)
+
+		_, err := svc.Count(context.Background(), notification.NotificationFilter{
+			Channel: notification.Channel("bogus"),
+		})
+		require.Error(t, err)
+	})
+}
+
+// ─── UpdateStatus ─────────────────────────────────────────────────────────
+
+func TestNotificationService_UpdateStatus(t *testing.T) {
+	t.Run("successful status update", func(t *testing.T) {
+		repo := newFullMockNotifRepo()
+		seedNotification(repo, "n1", "app-1", "user-1", notification.StatusQueued)
+		svc := newMethodTestService(repo, nil)
+
+		err := svc.UpdateStatus(context.Background(), "n1", notification.StatusProcessing, "", "app-1")
+		require.NoError(t, err)
+		assert.Equal(t, notification.StatusProcessing, repo.statusUpdates["n1"])
+	})
+
+	t.Run("status update with error message", func(t *testing.T) {
+		repo := newFullMockNotifRepo()
+		seedNotification(repo, "n1", "app-1", "user-1", notification.StatusQueued)
+		svc := newMethodTestService(repo, nil)
+
+		err := svc.UpdateStatus(context.Background(), "n1", notification.StatusFailed, "provider timeout", "app-1")
+		require.NoError(t, err)
+		assert.Equal(t, "provider timeout", repo.notifications["n1"].ErrorMessage)
+	})
+
+	t.Run("invalid status returns error", func(t *testing.T) {
+		svc := newMethodTestService(nil, nil)
+
+		err := svc.UpdateStatus(context.Background(), "n1", notification.Status("bogus"), "", "app-1")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, notification.ErrInvalidStatus)
+	})
+
+	t.Run("notification not found returns error", func(t *testing.T) {
+		svc := newMethodTestService(nil, nil)
+
+		err := svc.UpdateStatus(context.Background(), "missing", notification.StatusSent, "", "app-1")
+		require.Error(t, err)
+	})
+
+	t.Run("wrong app returns error", func(t *testing.T) {
+		repo := newFullMockNotifRepo()
+		seedNotification(repo, "n1", "app-1", "user-1", notification.StatusQueued)
+		svc := newMethodTestService(repo, nil)
+
+		err := svc.UpdateStatus(context.Background(), "n1", notification.StatusSent, "", "app-OTHER")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "notification not found")
+	})
+
+	t.Run("final state cannot be updated", func(t *testing.T) {
+		repo := newFullMockNotifRepo()
+		seedNotification(repo, "n1", "app-1", "user-1", notification.StatusDelivered)
+		svc := newMethodTestService(repo, nil)
+
+		err := svc.UpdateStatus(context.Background(), "n1", notification.StatusRead, "", "app-1")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "final state")
+	})
+}
+
+// ─── Cancel ───────────────────────────────────────────────────────────────
+
+func TestNotificationService_Cancel(t *testing.T) {
+	t.Run("successful cancel", func(t *testing.T) {
+		repo := newFullMockNotifRepo()
+		q := &fullMockQueue{}
+		seedNotification(repo, "n1", "app-1", "user-1", notification.StatusQueued)
+		svc := newMethodTestService(repo, q)
+
+		err := svc.Cancel(context.Background(), "n1", "app-1")
+		require.NoError(t, err)
+		assert.Equal(t, notification.StatusCancelled, repo.statusUpdates["n1"])
+		assert.Contains(t, q.removedIDs, "n1")
+	})
+
+	t.Run("not found returns error", func(t *testing.T) {
+		svc := newMethodTestService(nil, nil)
+
+		err := svc.Cancel(context.Background(), "missing", "app-1")
+		require.Error(t, err)
+	})
+
+	t.Run("wrong app returns error", func(t *testing.T) {
+		repo := newFullMockNotifRepo()
+		seedNotification(repo, "n1", "app-1", "user-1", notification.StatusQueued)
+		svc := newMethodTestService(repo, nil)
+
+		err := svc.Cancel(context.Background(), "n1", "app-OTHER")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "notification not found")
+	})
+
+	t.Run("sent notification cannot be cancelled", func(t *testing.T) {
+		repo := newFullMockNotifRepo()
+		seedNotification(repo, "n1", "app-1", "user-1", notification.StatusSent)
+		svc := newMethodTestService(repo, nil)
+
+		err := svc.Cancel(context.Background(), "n1", "app-1")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, notification.ErrCannotCancelSent)
+	})
+
+	t.Run("delivered notification cannot be cancelled", func(t *testing.T) {
+		repo := newFullMockNotifRepo()
+		seedNotification(repo, "n1", "app-1", "user-1", notification.StatusDelivered)
+		svc := newMethodTestService(repo, nil)
+
+		err := svc.Cancel(context.Background(), "n1", "app-1")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, notification.ErrCannotCancelSent)
+	})
+
+	t.Run("already failed notification cannot be cancelled", func(t *testing.T) {
+		repo := newFullMockNotifRepo()
+		seedNotification(repo, "n1", "app-1", "user-1", notification.StatusFailed)
+		svc := newMethodTestService(repo, nil)
+
+		err := svc.Cancel(context.Background(), "n1", "app-1")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "final state")
+	})
+}
+
+// ─── CancelBatch ──────────────────────────────────────────────────────────
+
+func TestNotificationService_CancelBatch(t *testing.T) {
+	t.Run("cancels eligible notifications", func(t *testing.T) {
+		repo := newFullMockNotifRepo()
+		q := &fullMockQueue{}
+		seedNotification(repo, "n1", "app-1", "user-1", notification.StatusQueued)
+		seedNotification(repo, "n2", "app-1", "user-1", notification.StatusPending)
+		svc := newMethodTestService(repo, q)
+
+		err := svc.CancelBatch(context.Background(), []string{"n1", "n2"}, "app-1")
+		require.NoError(t, err)
+		assert.Len(t, repo.bulkStatusIDs, 2)
+		assert.Equal(t, notification.StatusCancelled, repo.bulkStatusTarget)
+		assert.Len(t, q.removedIDs, 2)
+	})
+
+	t.Run("skips wrong app", func(t *testing.T) {
+		repo := newFullMockNotifRepo()
+		seedNotification(repo, "n1", "app-1", "user-1", notification.StatusQueued)
+		seedNotification(repo, "n2", "app-OTHER", "user-1", notification.StatusQueued)
+		svc := newMethodTestService(repo, nil)
+
+		err := svc.CancelBatch(context.Background(), []string{"n1", "n2"}, "app-1")
+		require.NoError(t, err)
+		assert.Len(t, repo.bulkStatusIDs, 1)
+		assert.Equal(t, "n1", repo.bulkStatusIDs[0])
+	})
+
+	t.Run("skips final-state notifications", func(t *testing.T) {
+		repo := newFullMockNotifRepo()
+		seedNotification(repo, "n1", "app-1", "user-1", notification.StatusQueued)
+		seedNotification(repo, "n2", "app-1", "user-1", notification.StatusDelivered)
+		seedNotification(repo, "n3", "app-1", "user-1", notification.StatusSent)
+		svc := newMethodTestService(repo, nil)
+
+		err := svc.CancelBatch(context.Background(), []string{"n1", "n2", "n3"}, "app-1")
+		require.NoError(t, err)
+		assert.Len(t, repo.bulkStatusIDs, 1)
+		assert.Equal(t, "n1", repo.bulkStatusIDs[0])
+	})
+
+	t.Run("skips not found", func(t *testing.T) {
+		repo := newFullMockNotifRepo()
+		seedNotification(repo, "n1", "app-1", "user-1", notification.StatusQueued)
+		svc := newMethodTestService(repo, nil)
+
+		err := svc.CancelBatch(context.Background(), []string{"n1", "missing"}, "app-1")
+		require.NoError(t, err)
+		assert.Len(t, repo.bulkStatusIDs, 1)
+	})
+
+	t.Run("all invalid returns nil", func(t *testing.T) {
+		svc := newMethodTestService(nil, nil)
+
+		err := svc.CancelBatch(context.Background(), []string{"missing1", "missing2"}, "app-1")
+		require.NoError(t, err)
+	})
+}
+
+// ─── Retry ────────────────────────────────────────────────────────────────
+
+func TestNotificationService_Retry(t *testing.T) {
+	t.Run("successful retry", func(t *testing.T) {
+		repo := newFullMockNotifRepo()
+		q := &fullMockQueue{}
+		n := seedNotification(repo, "n1", "app-1", "user-1", notification.StatusFailed)
+		n.RetryCount = 0
+		svc := newMethodTestService(repo, q)
+
+		err := svc.Retry(context.Background(), "n1", "app-1")
+		require.NoError(t, err)
+		assert.Contains(t, repo.incrementedRetryIDs, "n1")
+		assert.Len(t, q.enqueuedItems, 1)
+		assert.Equal(t, "n1", q.enqueuedItems[0].NotificationID)
+		assert.Equal(t, notification.StatusQueued, repo.statusUpdates["n1"])
+	})
+
+	t.Run("not found returns error", func(t *testing.T) {
+		svc := newMethodTestService(nil, nil)
+
+		err := svc.Retry(context.Background(), "missing", "app-1")
+		require.Error(t, err)
+	})
+
+	t.Run("wrong app returns error", func(t *testing.T) {
+		repo := newFullMockNotifRepo()
+		seedNotification(repo, "n1", "app-1", "user-1", notification.StatusFailed)
+		svc := newMethodTestService(repo, nil)
+
+		err := svc.Retry(context.Background(), "n1", "app-OTHER")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "notification not found")
+	})
+
+	t.Run("max retries exceeded", func(t *testing.T) {
+		repo := newFullMockNotifRepo()
+		n := seedNotification(repo, "n1", "app-1", "user-1", notification.StatusFailed)
+		n.RetryCount = 3 // equals maxRetries
+		svc := newMethodTestService(repo, nil)
+
+		err := svc.Retry(context.Background(), "n1", "app-1")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, notification.ErrMaxRetriesExceeded)
+	})
+
+	t.Run("non-failed notification cannot be retried", func(t *testing.T) {
+		repo := newFullMockNotifRepo()
+		seedNotification(repo, "n1", "app-1", "user-1", notification.StatusQueued)
+		svc := newMethodTestService(repo, nil)
+
+		err := svc.Retry(context.Background(), "n1", "app-1")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, notification.ErrCannotRetry)
+	})
+
+	t.Run("app retry limit overrides default", func(t *testing.T) {
+		repo := newFullMockNotifRepo()
+		n := seedNotification(repo, "n1", "app-1", "user-1", notification.StatusFailed)
+		n.RetryCount = 1
+		q := &fullMockQueue{}
+
+		// App has RetryAttempts=5, so retryCount=1 < 5 should succeed
+		apps := map[string]*application.Application{
+			"app-1": {AppID: "app-1", Settings: application.Settings{RetryAttempts: 5}},
+		}
+		svc := NewNotificationService(
+			repo,
+			&mockUserRepo{users: map[string]*user.User{}},
+			&mockAppRepoSend{apps: apps},
+			&mockTemplateRepoNSC{},
+			q,
+			zap.NewNop(),
+			NotificationServiceConfig{MaxRetries: 1}, // default would block at retryCount=1
+			nil,
+			&mockLimiterSend{allowed: true},
+		).(*NotificationService)
+
+		err := svc.Retry(context.Background(), "n1", "app-1")
+		require.NoError(t, err)
+	})
+}
+
+// ─── FlushQueued ──────────────────────────────────────────────────────────
+
+func TestNotificationService_FlushQueued(t *testing.T) {
+	t.Run("flushes queued notifications", func(t *testing.T) {
+		repo := newFullMockNotifRepo()
+		q := &fullMockQueue{}
+		repo.listResult = []*notification.Notification{
+			{NotificationID: "n1", AppID: "app-1", Priority: notification.PriorityNormal},
+			{NotificationID: "n2", AppID: "app-1", Priority: notification.PriorityHigh},
+		}
+		svc := newMethodTestService(repo, q)
+
+		err := svc.FlushQueued(context.Background(), "user-1")
+		require.NoError(t, err)
+		assert.Len(t, q.priorityItems, 2)
+		assert.Equal(t, "n1", q.priorityItems[0].NotificationID)
+		assert.Equal(t, "n2", q.priorityItems[1].NotificationID)
+	})
+
+	t.Run("no queued notifications is no-op", func(t *testing.T) {
+		repo := newFullMockNotifRepo()
+		repo.listResult = nil
+		q := &fullMockQueue{}
+		svc := newMethodTestService(repo, q)
+
+		err := svc.FlushQueued(context.Background(), "user-1")
+		require.NoError(t, err)
+		assert.Len(t, q.priorityItems, 0)
+	})
+
+	t.Run("list error returns error", func(t *testing.T) {
+		repo := newFullMockNotifRepo()
+		repo.listErr = fmt.Errorf("es down")
+		svc := newMethodTestService(repo, nil)
+
+		err := svc.FlushQueued(context.Background(), "user-1")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to list queued notifications")
+	})
+}
+
+// ─── GetUnreadCount ───────────────────────────────────────────────────────
+
+func TestNotificationService_GetUnreadCount(t *testing.T) {
+	t.Run("returns count from repo", func(t *testing.T) {
+		repo := newFullMockNotifRepo()
+		repo.countResult = 7
+		svc := newMethodTestService(repo, nil)
+
+		count, err := svc.GetUnreadCount(context.Background(), "user-1", "app-1")
+		require.NoError(t, err)
+		assert.Equal(t, int64(7), count)
+	})
+
+	t.Run("repo error propagates", func(t *testing.T) {
+		repo := newFullMockNotifRepo()
+		repo.countErr = fmt.Errorf("es down")
+		svc := newMethodTestService(repo, nil)
+
+		_, err := svc.GetUnreadCount(context.Background(), "user-1", "app-1")
+		require.Error(t, err)
+	})
+}
+
+// ─── MarkRead ─────────────────────────────────────────────────────────────
+
+func TestNotificationService_MarkRead(t *testing.T) {
+	t.Run("marks owned notifications as read", func(t *testing.T) {
+		repo := newFullMockNotifRepo()
+		seedNotification(repo, "n1", "app-1", "user-1", notification.StatusSent)
+		seedNotification(repo, "n2", "app-1", "user-1", notification.StatusSent)
+		svc := newMethodTestService(repo, nil)
+
+		err := svc.MarkRead(context.Background(), []string{"n1", "n2"}, "app-1", "user-1")
+		require.NoError(t, err)
+		assert.Equal(t, notification.StatusRead, repo.bulkStatusTarget)
+		assert.Len(t, repo.bulkStatusIDs, 2)
+	})
+
+	t.Run("wrong user returns error", func(t *testing.T) {
+		repo := newFullMockNotifRepo()
+		seedNotification(repo, "n1", "app-1", "user-1", notification.StatusSent)
+		svc := newMethodTestService(repo, nil)
+
+		err := svc.MarkRead(context.Background(), []string{"n1"}, "app-1", "user-OTHER")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not belong to user")
+	})
+
+	t.Run("wrong app returns error", func(t *testing.T) {
+		repo := newFullMockNotifRepo()
+		seedNotification(repo, "n1", "app-1", "user-1", notification.StatusSent)
+		svc := newMethodTestService(repo, nil)
+
+		err := svc.MarkRead(context.Background(), []string{"n1"}, "app-OTHER", "user-1")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not belong to user")
+	})
+
+	t.Run("not found notification is skipped", func(t *testing.T) {
+		repo := newFullMockNotifRepo()
+		seedNotification(repo, "n1", "app-1", "user-1", notification.StatusSent)
+		svc := newMethodTestService(repo, nil)
+
+		// "missing" is not found → skipped, "n1" passes ownership check
+		err := svc.MarkRead(context.Background(), []string{"missing", "n1"}, "app-1", "user-1")
+		require.NoError(t, err)
+	})
+}
+
+// ─── ListUnread ───────────────────────────────────────────────────────────
+
+func TestNotificationService_ListUnread(t *testing.T) {
+	t.Run("returns unread notifications", func(t *testing.T) {
+		repo := newFullMockNotifRepo()
+		repo.listResult = []*notification.Notification{
+			{NotificationID: "n1", Status: notification.StatusSent},
+		}
+		svc := newMethodTestService(repo, nil)
+
+		results, err := svc.ListUnread(context.Background(), "user-1", "app-1")
+		require.NoError(t, err)
+		assert.Len(t, results, 1)
+	})
+}
+
+// ─── Snooze ───────────────────────────────────────────────────────────────
+
+func TestNotificationService_Snooze(t *testing.T) {
+	t.Run("successful snooze", func(t *testing.T) {
+		repo := newFullMockNotifRepo()
+		q := &fullMockQueue{}
+		seedNotification(repo, "n1", "app-1", "user-1", notification.StatusQueued)
+		svc := newMethodTestService(repo, q)
+
+		until := time.Now().Add(1 * time.Hour)
+		err := svc.Snooze(context.Background(), "n1", "app-1", until)
+		require.NoError(t, err)
+		assert.Equal(t, notification.StatusSnoozed, repo.snoozeUpdates["n1"])
+		assert.Contains(t, q.removedIDs, "n1")
+	})
+
+	t.Run("not found returns error", func(t *testing.T) {
+		svc := newMethodTestService(nil, nil)
+
+		err := svc.Snooze(context.Background(), "missing", "app-1", time.Now().Add(time.Hour))
+		require.Error(t, err)
+		assert.ErrorIs(t, err, notification.ErrNotificationNotFound)
+	})
+
+	t.Run("wrong app returns not found", func(t *testing.T) {
+		repo := newFullMockNotifRepo()
+		seedNotification(repo, "n1", "app-1", "user-1", notification.StatusQueued)
+		svc := newMethodTestService(repo, nil)
+
+		err := svc.Snooze(context.Background(), "n1", "app-OTHER", time.Now().Add(time.Hour))
+		require.Error(t, err)
+		assert.ErrorIs(t, err, notification.ErrNotificationNotFound)
+	})
+
+	t.Run("already snoozed returns error", func(t *testing.T) {
+		repo := newFullMockNotifRepo()
+		seedNotification(repo, "n1", "app-1", "user-1", notification.StatusSnoozed)
+		svc := newMethodTestService(repo, nil)
+
+		err := svc.Snooze(context.Background(), "n1", "app-1", time.Now().Add(time.Hour))
+		require.Error(t, err)
+		assert.ErrorIs(t, err, notification.ErrCannotSnooze)
+	})
+
+	t.Run("final state cannot be snoozed", func(t *testing.T) {
+		repo := newFullMockNotifRepo()
+		seedNotification(repo, "n1", "app-1", "user-1", notification.StatusDelivered)
+		svc := newMethodTestService(repo, nil)
+
+		err := svc.Snooze(context.Background(), "n1", "app-1", time.Now().Add(time.Hour))
+		require.Error(t, err)
+		assert.ErrorIs(t, err, notification.ErrCannotSnooze)
+	})
+
+	t.Run("past time returns error", func(t *testing.T) {
+		repo := newFullMockNotifRepo()
+		seedNotification(repo, "n1", "app-1", "user-1", notification.StatusQueued)
+		svc := newMethodTestService(repo, nil)
+
+		err := svc.Snooze(context.Background(), "n1", "app-1", time.Now().Add(-1*time.Hour))
+		require.Error(t, err)
+		assert.ErrorIs(t, err, notification.ErrInvalidSnoozeDuration)
+	})
+}
+
+// ─── Unsnooze ─────────────────────────────────────────────────────────────
+
+func TestNotificationService_Unsnooze(t *testing.T) {
+	t.Run("successful unsnooze", func(t *testing.T) {
+		repo := newFullMockNotifRepo()
+		q := &fullMockQueue{}
+		seedNotification(repo, "n1", "app-1", "user-1", notification.StatusSnoozed)
+		svc := newMethodTestService(repo, q)
+
+		err := svc.Unsnooze(context.Background(), "n1", "app-1")
+		require.NoError(t, err)
+		assert.Equal(t, notification.StatusQueued, repo.snoozeUpdates["n1"])
+		assert.Len(t, q.enqueuedItems, 1)
+		assert.Equal(t, "n1", q.enqueuedItems[0].NotificationID)
+	})
+
+	t.Run("not found returns error", func(t *testing.T) {
+		svc := newMethodTestService(nil, nil)
+
+		err := svc.Unsnooze(context.Background(), "missing", "app-1")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, notification.ErrNotificationNotFound)
+	})
+
+	t.Run("wrong app returns not found", func(t *testing.T) {
+		repo := newFullMockNotifRepo()
+		seedNotification(repo, "n1", "app-1", "user-1", notification.StatusSnoozed)
+		svc := newMethodTestService(repo, nil)
+
+		err := svc.Unsnooze(context.Background(), "n1", "app-OTHER")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, notification.ErrNotificationNotFound)
+	})
+
+	t.Run("non-snoozed notification returns error", func(t *testing.T) {
+		repo := newFullMockNotifRepo()
+		seedNotification(repo, "n1", "app-1", "user-1", notification.StatusQueued)
+		svc := newMethodTestService(repo, nil)
+
+		err := svc.Unsnooze(context.Background(), "n1", "app-1")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, notification.ErrCannotSnooze)
+	})
+}
+
+// ─── Archive ──────────────────────────────────────────────────────────────
+
+func TestNotificationService_Archive(t *testing.T) {
+	t.Run("archives owned notifications", func(t *testing.T) {
+		repo := newFullMockNotifRepo()
+		seedNotification(repo, "n1", "app-1", "user-1", notification.StatusSent)
+		seedNotification(repo, "n2", "app-1", "user-1", notification.StatusRead)
+		svc := newMethodTestService(repo, nil)
+
+		err := svc.Archive(context.Background(), []string{"n1", "n2"}, "app-1", "user-1")
+		require.NoError(t, err)
+		assert.Len(t, repo.bulkArchiveIDs, 2)
+	})
+
+	t.Run("not found returns error", func(t *testing.T) {
+		svc := newMethodTestService(nil, nil)
+
+		err := svc.Archive(context.Background(), []string{"missing"}, "app-1", "user-1")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, notification.ErrNotificationNotFound)
+	})
+
+	t.Run("wrong user returns error", func(t *testing.T) {
+		repo := newFullMockNotifRepo()
+		seedNotification(repo, "n1", "app-1", "user-1", notification.StatusSent)
+		svc := newMethodTestService(repo, nil)
+
+		err := svc.Archive(context.Background(), []string{"n1"}, "app-1", "user-OTHER")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not belong to user")
+	})
+
+	t.Run("wrong app returns error", func(t *testing.T) {
+		repo := newFullMockNotifRepo()
+		seedNotification(repo, "n1", "app-1", "user-1", notification.StatusSent)
+		svc := newMethodTestService(repo, nil)
+
+		err := svc.Archive(context.Background(), []string{"n1"}, "app-OTHER", "user-1")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not belong to user")
+	})
+
+	t.Run("already archived is allowed", func(t *testing.T) {
+		repo := newFullMockNotifRepo()
+		seedNotification(repo, "n1", "app-1", "user-1", notification.StatusArchived)
+		svc := newMethodTestService(repo, nil)
+
+		err := svc.Archive(context.Background(), []string{"n1"}, "app-1", "user-1")
+		require.NoError(t, err)
+	})
+}
+
+// ─── MarkAllRead ──────────────────────────────────────────────────────────
+
+func TestNotificationService_MarkAllRead(t *testing.T) {
+	t.Run("successful mark all read", func(t *testing.T) {
+		repo := newFullMockNotifRepo()
+		repo.markAllReadCount = 5
+		svc := newMethodTestService(repo, nil)
+
+		err := svc.MarkAllRead(context.Background(), "user-1", "app-1", "")
+		require.NoError(t, err)
+	})
+
+	t.Run("repo error propagates", func(t *testing.T) {
+		repo := newFullMockNotifRepo()
+		repo.markAllReadErr = fmt.Errorf("es down")
+		svc := newMethodTestService(repo, nil)
+
+		err := svc.MarkAllRead(context.Background(), "user-1", "app-1", "")
+		require.Error(t, err)
+	})
+}
+
+// ─── ListSnoozedDue ──────────────────────────────────────────────────────
+
+func TestNotificationService_ListSnoozedDue(t *testing.T) {
+	t.Run("returns snoozed due from repo", func(t *testing.T) {
+		repo := newFullMockNotifRepo()
+		repo.snoozedDueResult = []*notification.Notification{
+			{NotificationID: "n1", Status: notification.StatusSnoozed},
+		}
+		svc := newMethodTestService(repo, nil)
+
+		results, err := svc.ListSnoozedDue(context.Background())
+		require.NoError(t, err)
+		assert.Len(t, results, 1)
+	})
+
+	t.Run("returns empty when none due", func(t *testing.T) {
+		svc := newMethodTestService(nil, nil)
+
+		results, err := svc.ListSnoozedDue(context.Background())
+		require.NoError(t, err)
+		assert.Len(t, results, 0)
+	})
+}
+
+// ─── SendBatch ────────────────────────────────────────────────────────────
+
+func TestNotificationService_SendBatch(t *testing.T) {
+	t.Run("processes multiple requests", func(t *testing.T) {
+		nrepo := &mockNotifRepoSend{}
+		q := &mockQueueSend{}
+		svc := newSendServiceForTest(defaultUsers(), defaultApps(), nrepo, q, nil)
+
+		results, err := svc.SendBatch(context.Background(), []notification.SendRequest{
+			{
+				AppID: "app-1", UserID: "user-1",
+				Channel: notification.ChannelEmail, Priority: notification.PriorityNormal,
+				Title: "First", Body: "Body1",
+			},
+			{
+				AppID: "app-1", UserID: "user-1",
+				Channel: notification.ChannelEmail, Priority: notification.PriorityNormal,
+				Title: "Second", Body: "Body2",
+			},
+		})
+
+		require.NoError(t, err)
+		assert.Len(t, results, 2)
+		assert.Equal(t, notification.StatusQueued, results[0].Status)
+		assert.Equal(t, notification.StatusQueued, results[1].Status)
+	})
+
+	t.Run("failed request returns failed notification item", func(t *testing.T) {
+		svc := newSendServiceForTest(defaultUsers(), defaultApps(), nil, nil, nil)
+
+		results, err := svc.SendBatch(context.Background(), []notification.SendRequest{
+			{
+				AppID: "app-1", UserID: "user-1",
+				Channel: notification.ChannelEmail, Priority: notification.PriorityNormal,
+				Title: "OK", Body: "Body",
+			},
+			{
+				AppID: "", // invalid
+			},
+		})
+
+		require.NoError(t, err) // SendBatch itself never errors
+		assert.Len(t, results, 2)
+		assert.Equal(t, notification.StatusQueued, results[0].Status)
+		assert.Equal(t, notification.StatusFailed, results[1].Status)
+		assert.NotEmpty(t, results[1].ErrorMessage)
+	})
+}
+
+// ─── isChannelEnabled ─────────────────────────────────────────────────────
+
+func TestNotificationService_isChannelEnabled(t *testing.T) {
+	t.Run("email enabled by user preference", func(t *testing.T) {
+		svc := newMethodTestService(nil, nil)
+		u := &user.User{
+			AppID:       "app-1",
+			Preferences: user.Preferences{EmailEnabled: boolPtr(true)},
+		}
+
+		assert.True(t, svc.isChannelEnabled(context.Background(), u, notification.ChannelEmail, ""))
+	})
+
+	t.Run("email disabled by user preference", func(t *testing.T) {
+		svc := newMethodTestService(nil, nil)
+		u := &user.User{
+			AppID:       "app-1",
+			Preferences: user.Preferences{EmailEnabled: boolPtr(false)},
+		}
+
+		assert.False(t, svc.isChannelEnabled(context.Background(), u, notification.ChannelEmail, ""))
+	})
+
+	t.Run("defaults to enabled when no preference set", func(t *testing.T) {
+		svc := newMethodTestService(nil, nil)
+		u := &user.User{
+			AppID:       "app-1",
+			Preferences: user.Preferences{},
+		}
+
+		assert.True(t, svc.isChannelEnabled(context.Background(), u, notification.ChannelPush, ""))
+	})
+
+	t.Run("category disabled blocks notification", func(t *testing.T) {
+		svc := newMethodTestService(nil, nil)
+		u := &user.User{
+			AppID: "app-1",
+			Preferences: user.Preferences{
+				EmailEnabled: boolPtr(true),
+				Categories: map[string]user.CategoryPreference{
+					"marketing": {Enabled: false},
+				},
+			},
+		}
+
+		assert.False(t, svc.isChannelEnabled(context.Background(), u, notification.ChannelEmail, "marketing"))
+	})
+
+	t.Run("category enabled channels override user preferences", func(t *testing.T) {
+		svc := newMethodTestService(nil, nil)
+		u := &user.User{
+			AppID: "app-1",
+			Preferences: user.Preferences{
+				EmailEnabled: boolPtr(true),
+				SMSEnabled:   boolPtr(true),
+				Categories: map[string]user.CategoryPreference{
+					"alerts": {Enabled: true, EnabledChannels: []string{"sms"}},
+				},
+			},
+		}
+
+		// Email is NOT in category's enabled channels
+		assert.False(t, svc.isChannelEnabled(context.Background(), u, notification.ChannelEmail, "alerts"))
+		// SMS IS in category's enabled channels
+		assert.True(t, svc.isChannelEnabled(context.Background(), u, notification.ChannelSMS, "alerts"))
+	})
+
+	t.Run("whatsapp preference respected", func(t *testing.T) {
+		svc := newMethodTestService(nil, nil)
+		u := &user.User{
+			AppID:       "app-1",
+			Preferences: user.Preferences{WhatsAppEnabled: boolPtr(false)},
+		}
+
+		assert.False(t, svc.isChannelEnabled(context.Background(), u, notification.ChannelWhatsApp, ""))
+	})
+}

--- a/internal/usecases/notification_service_send_test.go
+++ b/internal/usecases/notification_service_send_test.go
@@ -663,3 +663,588 @@ func TestNotificationService_Send(t *testing.T) {
 		assert.Contains(t, err.Error(), "failed to create notification")
 	})
 }
+
+// ─── SendBulk Tests ───────────────────────────────────────────────────────
+
+// mockNotifRepoBulk tracks BulkUpdateStatus calls.
+type mockNotifRepoBulk struct {
+	mockNotifRepoSend
+	bulkStatusIDs    []string
+	bulkStatusTarget notification.Status
+}
+
+func (m *mockNotifRepoBulk) BulkUpdateStatus(ctx context.Context, ids []string, status notification.Status) error {
+	m.bulkStatusIDs = ids
+	m.bulkStatusTarget = status
+	return nil
+}
+
+// mockQueueBulk tracks EnqueueBatch calls with configurable error.
+type mockQueueBulk struct {
+	mockQueue
+	batchErr error
+}
+
+func (m *mockQueueBulk) EnqueueBatch(ctx context.Context, items []notifqueue.NotificationQueueItem) error {
+	if m.batchErr != nil {
+		return m.batchErr
+	}
+	m.batch = append(m.batch, items...)
+	return nil
+}
+
+func newBulkServiceForTest(
+	users map[string]*user.User,
+	apps map[string]*application.Application,
+	nrepo *mockNotifRepoBulk,
+	q *mockQueueBulk,
+	lim *mockLimiterSend,
+) *NotificationService {
+	if nrepo == nil {
+		nrepo = &mockNotifRepoBulk{}
+	}
+	if q == nil {
+		q = &mockQueueBulk{}
+	}
+	if lim == nil {
+		lim = &mockLimiterSend{allowed: true}
+	}
+	return NewNotificationService(
+		nrepo,
+		&mockUserRepoSend{mockUserRepo{users: users}},
+		&mockAppRepoSend{apps: apps},
+		&mockTemplateRepoNSC{},
+		q,
+		zap.NewNop(),
+		NotificationServiceConfig{MaxRetries: 3},
+		nil,
+		lim,
+	).(*NotificationService)
+}
+
+func TestNotificationService_SendBulk(t *testing.T) {
+	t.Run("successful bulk send to two users", func(t *testing.T) {
+		u1 := defaultUser()
+		u2 := &user.User{
+			UserID: "user-2", AppID: "app-1",
+			Email: "bob@example.com", Phone: "+15559876543",
+			Preferences: user.Preferences{
+				EmailEnabled: boolPtr(true),
+			},
+		}
+		users := map[string]*user.User{u1.UserID: u1, u2.UserID: u2}
+		nrepo := &mockNotifRepoBulk{}
+		q := &mockQueueBulk{}
+		svc := newBulkServiceForTest(users, defaultApps(), nrepo, q, nil)
+
+		results, err := svc.SendBulk(context.Background(), notification.BulkSendRequest{
+			AppID:    "app-1",
+			UserIDs:  []string{"user-1", "user-2"},
+			Channel:  notification.ChannelEmail,
+			Priority: notification.PriorityNormal,
+			Title:    "Hello",
+			Body:     "World",
+		})
+
+		require.NoError(t, err)
+		assert.Len(t, results, 2)
+		assert.Len(t, nrepo.created, 2)
+		assert.Len(t, q.batch, 2)
+		assert.Equal(t, notification.StatusQueued, nrepo.bulkStatusTarget)
+		assert.Len(t, nrepo.bulkStatusIDs, 2)
+	})
+
+	t.Run("validation error — empty AppID", func(t *testing.T) {
+		svc := newBulkServiceForTest(defaultUsers(), defaultApps(), nil, nil, nil)
+
+		_, err := svc.SendBulk(context.Background(), notification.BulkSendRequest{
+			AppID:    "",
+			UserIDs:  []string{"user-1"},
+			Channel:  notification.ChannelEmail,
+			Priority: notification.PriorityNormal,
+			Title:    "Hi",
+			Body:     "Body",
+		})
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, notification.ErrInvalidAppID)
+	})
+
+	t.Run("validation error — empty UserIDs", func(t *testing.T) {
+		svc := newBulkServiceForTest(defaultUsers(), defaultApps(), nil, nil, nil)
+
+		_, err := svc.SendBulk(context.Background(), notification.BulkSendRequest{
+			AppID:    "app-1",
+			UserIDs:  []string{},
+			Channel:  notification.ChannelEmail,
+			Priority: notification.PriorityNormal,
+			Title:    "Hi",
+			Body:     "Body",
+		})
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, notification.ErrInvalidUserID)
+	})
+
+	t.Run("validation error — no content", func(t *testing.T) {
+		svc := newBulkServiceForTest(defaultUsers(), defaultApps(), nil, nil, nil)
+
+		_, err := svc.SendBulk(context.Background(), notification.BulkSendRequest{
+			AppID:    "app-1",
+			UserIDs:  []string{"user-1"},
+			Channel:  notification.ChannelEmail,
+			Priority: notification.PriorityNormal,
+		})
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, notification.ErrEmptyContent)
+	})
+
+	t.Run("content_sid in data passes validation", func(t *testing.T) {
+		nrepo := &mockNotifRepoBulk{}
+		svc := newBulkServiceForTest(defaultUsers(), defaultApps(), nrepo, nil, nil)
+
+		results, err := svc.SendBulk(context.Background(), notification.BulkSendRequest{
+			AppID:    "app-1",
+			UserIDs:  []string{"user-1"},
+			Channel:  notification.ChannelWhatsApp,
+			Priority: notification.PriorityNormal,
+			Data:     map[string]interface{}{"content_sid": "HX123abc"},
+		})
+
+		require.NoError(t, err)
+		assert.Len(t, results, 1)
+	})
+
+	t.Run("media_url in data passes validation", func(t *testing.T) {
+		nrepo := &mockNotifRepoBulk{}
+		svc := newBulkServiceForTest(defaultUsers(), defaultApps(), nrepo, nil, nil)
+
+		results, err := svc.SendBulk(context.Background(), notification.BulkSendRequest{
+			AppID:    "app-1",
+			UserIDs:  []string{"user-1"},
+			Channel:  notification.ChannelWhatsApp,
+			Priority: notification.PriorityNormal,
+			Data:     map[string]interface{}{"media_url": "https://example.com/file.pdf"},
+		})
+
+		require.NoError(t, err)
+		assert.Len(t, results, 1)
+		// media_url promoted to Content.MediaURL
+		assert.Equal(t, "https://example.com/file.pdf", nrepo.created[0].Content.MediaURL)
+	})
+
+	t.Run("explicit MediaURL field passes validation", func(t *testing.T) {
+		nrepo := &mockNotifRepoBulk{}
+		svc := newBulkServiceForTest(defaultUsers(), defaultApps(), nrepo, nil, nil)
+
+		results, err := svc.SendBulk(context.Background(), notification.BulkSendRequest{
+			AppID:    "app-1",
+			UserIDs:  []string{"user-1"},
+			Channel:  notification.ChannelWhatsApp,
+			Priority: notification.PriorityNormal,
+			MediaURL: "https://example.com/image.png",
+		})
+
+		require.NoError(t, err)
+		assert.Len(t, results, 1)
+		assert.Equal(t, "https://example.com/image.png", nrepo.created[0].Content.MediaURL)
+	})
+
+	t.Run("explicit MediaURL takes precedence over data.media_url", func(t *testing.T) {
+		nrepo := &mockNotifRepoBulk{}
+		svc := newBulkServiceForTest(defaultUsers(), defaultApps(), nrepo, nil, nil)
+
+		results, err := svc.SendBulk(context.Background(), notification.BulkSendRequest{
+			AppID:    "app-1",
+			UserIDs:  []string{"user-1"},
+			Channel:  notification.ChannelWhatsApp,
+			Priority: notification.PriorityNormal,
+			MediaURL: "https://example.com/explicit.png",
+			Data:     map[string]interface{}{"media_url": "https://example.com/data.png"},
+		})
+
+		require.NoError(t, err)
+		assert.Len(t, results, 1)
+		assert.Equal(t, "https://example.com/explicit.png", nrepo.created[0].Content.MediaURL)
+	})
+
+	t.Run("unknown user skipped", func(t *testing.T) {
+		nrepo := &mockNotifRepoBulk{}
+		q := &mockQueueBulk{}
+		svc := newBulkServiceForTest(defaultUsers(), defaultApps(), nrepo, q, nil)
+
+		results, err := svc.SendBulk(context.Background(), notification.BulkSendRequest{
+			AppID:    "app-1",
+			UserIDs:  []string{"user-1", "nonexistent"},
+			Channel:  notification.ChannelEmail,
+			Priority: notification.PriorityNormal,
+			Title:    "Hello",
+			Body:     "World",
+		})
+
+		require.NoError(t, err)
+		assert.Len(t, results, 1)
+		assert.Equal(t, "user-1", results[0].UserID)
+	})
+
+	t.Run("DND user skipped for non-critical", func(t *testing.T) {
+		u1 := defaultUser()
+		u2 := &user.User{
+			UserID: "user-2", AppID: "app-1",
+			Email: "bob@example.com", Phone: "+15559876543",
+			Preferences: user.Preferences{
+				DND:          true,
+				EmailEnabled: boolPtr(true),
+			},
+		}
+		users := map[string]*user.User{u1.UserID: u1, u2.UserID: u2}
+		nrepo := &mockNotifRepoBulk{}
+		svc := newBulkServiceForTest(users, defaultApps(), nrepo, nil, nil)
+
+		results, err := svc.SendBulk(context.Background(), notification.BulkSendRequest{
+			AppID:    "app-1",
+			UserIDs:  []string{"user-1", "user-2"},
+			Channel:  notification.ChannelEmail,
+			Priority: notification.PriorityNormal,
+			Title:    "Hello",
+			Body:     "World",
+		})
+
+		require.NoError(t, err)
+		assert.Len(t, results, 1)
+		assert.Equal(t, "user-1", results[0].UserID)
+	})
+
+	t.Run("DND user included for critical priority", func(t *testing.T) {
+		u1 := defaultUser()
+		u2 := &user.User{
+			UserID: "user-2", AppID: "app-1",
+			Email: "bob@example.com", Phone: "+15559876543",
+			Preferences: user.Preferences{
+				DND:          true,
+				EmailEnabled: boolPtr(true),
+			},
+		}
+		users := map[string]*user.User{u1.UserID: u1, u2.UserID: u2}
+		nrepo := &mockNotifRepoBulk{}
+		svc := newBulkServiceForTest(users, defaultApps(), nrepo, nil, nil)
+
+		results, err := svc.SendBulk(context.Background(), notification.BulkSendRequest{
+			AppID:    "app-1",
+			UserIDs:  []string{"user-1", "user-2"},
+			Channel:  notification.ChannelEmail,
+			Priority: notification.PriorityCritical,
+			Title:    "URGENT",
+			Body:     "System down",
+		})
+
+		require.NoError(t, err)
+		assert.Len(t, results, 2)
+	})
+
+	t.Run("missing phone for WhatsApp skipped", func(t *testing.T) {
+		u := defaultUser()
+		u.Phone = ""
+		users := map[string]*user.User{u.UserID: u}
+		nrepo := &mockNotifRepoBulk{}
+		svc := newBulkServiceForTest(users, defaultApps(), nrepo, nil, nil)
+
+		results, err := svc.SendBulk(context.Background(), notification.BulkSendRequest{
+			AppID:    "app-1",
+			UserIDs:  []string{"user-1"},
+			Channel:  notification.ChannelWhatsApp,
+			Priority: notification.PriorityNormal,
+			Data:     map[string]interface{}{"content_sid": "HX123"},
+		})
+
+		require.NoError(t, err)
+		assert.Len(t, results, 0)
+	})
+
+	t.Run("missing email for email channel skipped", func(t *testing.T) {
+		u := defaultUser()
+		u.Email = ""
+		users := map[string]*user.User{u.UserID: u}
+		nrepo := &mockNotifRepoBulk{}
+		svc := newBulkServiceForTest(users, defaultApps(), nrepo, nil, nil)
+
+		results, err := svc.SendBulk(context.Background(), notification.BulkSendRequest{
+			AppID:    "app-1",
+			UserIDs:  []string{"user-1"},
+			Channel:  notification.ChannelEmail,
+			Priority: notification.PriorityNormal,
+			Title:    "Hello",
+			Body:     "World",
+		})
+
+		require.NoError(t, err)
+		assert.Len(t, results, 0)
+	})
+
+	t.Run("channel disabled in preferences skipped", func(t *testing.T) {
+		u := defaultUser()
+		u.Preferences.EmailEnabled = boolPtr(false)
+		users := map[string]*user.User{u.UserID: u}
+		nrepo := &mockNotifRepoBulk{}
+		svc := newBulkServiceForTest(users, defaultApps(), nrepo, nil, nil)
+
+		results, err := svc.SendBulk(context.Background(), notification.BulkSendRequest{
+			AppID:    "app-1",
+			UserIDs:  []string{"user-1"},
+			Channel:  notification.ChannelEmail,
+			Priority: notification.PriorityNormal,
+			Title:    "Hello",
+			Body:     "World",
+		})
+
+		require.NoError(t, err)
+		assert.Len(t, results, 0)
+	})
+
+	t.Run("duplicate contacts deduplicated", func(t *testing.T) {
+		u1 := defaultUser()
+		// u2 has same email as u1
+		u2 := &user.User{
+			UserID: "user-2", AppID: "app-1",
+			Email: "alice@example.com", Phone: "+15551234567",
+			Preferences: user.Preferences{
+				EmailEnabled: boolPtr(true),
+			},
+		}
+		users := map[string]*user.User{u1.UserID: u1, u2.UserID: u2}
+		nrepo := &mockNotifRepoBulk{}
+		svc := newBulkServiceForTest(users, defaultApps(), nrepo, nil, nil)
+
+		results, err := svc.SendBulk(context.Background(), notification.BulkSendRequest{
+			AppID:    "app-1",
+			UserIDs:  []string{"user-1", "user-2"},
+			Channel:  notification.ChannelEmail,
+			Priority: notification.PriorityNormal,
+			Title:    "Hello",
+			Body:     "World",
+		})
+
+		require.NoError(t, err)
+		assert.Len(t, results, 1, "duplicate email should be deduplicated")
+	})
+
+	t.Run("daily limit exceeded skips user", func(t *testing.T) {
+		u := defaultUser()
+		u.Preferences.DailyLimit = 5
+		users := map[string]*user.User{u.UserID: u}
+		lim := &mockLimiterSend{
+			incrementAndResp: map[string]bool{"user:user-1": false},
+		}
+		nrepo := &mockNotifRepoBulk{}
+		svc := newBulkServiceForTest(users, defaultApps(), nrepo, nil, lim)
+
+		results, err := svc.SendBulk(context.Background(), notification.BulkSendRequest{
+			AppID:    "app-1",
+			UserIDs:  []string{"user-1"},
+			Channel:  notification.ChannelEmail,
+			Priority: notification.PriorityNormal,
+			Title:    "Hello",
+			Body:     "World",
+		})
+
+		require.NoError(t, err)
+		assert.Len(t, results, 0)
+	})
+
+	t.Run("daily limit exceeded allows critical", func(t *testing.T) {
+		u := defaultUser()
+		u.Preferences.DailyLimit = 5
+		users := map[string]*user.User{u.UserID: u}
+		lim := &mockLimiterSend{
+			incrementAndResp: map[string]bool{"user:user-1": false},
+		}
+		nrepo := &mockNotifRepoBulk{}
+		svc := newBulkServiceForTest(users, defaultApps(), nrepo, nil, lim)
+
+		results, err := svc.SendBulk(context.Background(), notification.BulkSendRequest{
+			AppID:    "app-1",
+			UserIDs:  []string{"user-1"},
+			Channel:  notification.ChannelEmail,
+			Priority: notification.PriorityCritical,
+			Title:    "URGENT",
+			Body:     "Fire",
+		})
+
+		require.NoError(t, err)
+		assert.Len(t, results, 1)
+	})
+
+	t.Run("metadata copied to notifications", func(t *testing.T) {
+		nrepo := &mockNotifRepoBulk{}
+		svc := newBulkServiceForTest(defaultUsers(), defaultApps(), nrepo, nil, nil)
+
+		results, err := svc.SendBulk(context.Background(), notification.BulkSendRequest{
+			AppID:    "app-1",
+			UserIDs:  []string{"user-1"},
+			Channel:  notification.ChannelEmail,
+			Priority: notification.PriorityNormal,
+			Title:    "Hello",
+			Body:     "World",
+			Metadata: map[string]interface{}{"digest_key": "daily"},
+		})
+
+		require.NoError(t, err)
+		assert.Len(t, results, 1)
+		assert.Equal(t, "daily", results[0].Metadata["digest_key"])
+	})
+
+	t.Run("scheduled bulk notifications use scheduled queue", func(t *testing.T) {
+		nrepo := &mockNotifRepoBulk{}
+		q := &mockQueueBulk{}
+		svc := newBulkServiceForTest(defaultUsers(), defaultApps(), nrepo, q, nil)
+
+		future := time.Now().Add(2 * time.Hour)
+		results, err := svc.SendBulk(context.Background(), notification.BulkSendRequest{
+			AppID:       "app-1",
+			UserIDs:     []string{"user-1"},
+			Channel:     notification.ChannelEmail,
+			Priority:    notification.PriorityNormal,
+			Title:       "Later",
+			Body:        "Scheduled",
+			ScheduledAt: &future,
+		})
+
+		require.NoError(t, err)
+		assert.Len(t, results, 1)
+		// Should NOT be in the regular batch queue
+		assert.Len(t, q.batch, 0)
+	})
+
+	t.Run("EnqueueBatch failure returns error with partial results", func(t *testing.T) {
+		nrepo := &mockNotifRepoBulk{}
+		q := &mockQueueBulk{batchErr: fmt.Errorf("redis down")}
+		svc := newBulkServiceForTest(defaultUsers(), defaultApps(), nrepo, q, nil)
+
+		results, err := svc.SendBulk(context.Background(), notification.BulkSendRequest{
+			AppID:    "app-1",
+			UserIDs:  []string{"user-1"},
+			Channel:  notification.ChannelEmail,
+			Priority: notification.PriorityNormal,
+			Title:    "Hello",
+			Body:     "World",
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to bulk enqueue")
+		// Notifications were still created in repo
+		assert.Len(t, results, 1)
+	})
+
+	t.Run("repo create failure skips user", func(t *testing.T) {
+		nrepo := &mockNotifRepoBulk{mockNotifRepoSend: mockNotifRepoSend{createErr: fmt.Errorf("es unavailable")}}
+		q := &mockQueueBulk{}
+		svc := newBulkServiceForTest(defaultUsers(), defaultApps(), nrepo, q, nil)
+
+		results, err := svc.SendBulk(context.Background(), notification.BulkSendRequest{
+			AppID:    "app-1",
+			UserIDs:  []string{"user-1"},
+			Channel:  notification.ChannelEmail,
+			Priority: notification.PriorityNormal,
+			Title:    "Hello",
+			Body:     "World",
+		})
+
+		require.NoError(t, err)
+		assert.Len(t, results, 0)
+		assert.Len(t, q.batch, 0)
+	})
+
+	t.Run("content fields preserved", func(t *testing.T) {
+		nrepo := &mockNotifRepoBulk{}
+		svc := newBulkServiceForTest(defaultUsers(), defaultApps(), nrepo, nil, nil)
+
+		results, err := svc.SendBulk(context.Background(), notification.BulkSendRequest{
+			AppID:    "app-1",
+			UserIDs:  []string{"user-1"},
+			Channel:  notification.ChannelEmail,
+			Priority: notification.PriorityHigh,
+			Title:    "Alert",
+			Body:     "Something happened",
+			Data:     map[string]interface{}{"key": "value"},
+			Category: "alerts",
+			MediaURL: "https://example.com/img.png",
+		})
+
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		n := results[0]
+		assert.Equal(t, "Alert", n.Content.Title)
+		assert.Equal(t, "Something happened", n.Content.Body)
+		assert.Equal(t, "value", n.Content.Data["key"])
+		assert.Equal(t, "https://example.com/img.png", n.Content.MediaURL)
+		assert.Equal(t, "alerts", n.Category)
+		assert.Equal(t, notification.PriorityHigh, n.Priority)
+	})
+
+	t.Run("SMS dedup by phone number", func(t *testing.T) {
+		u1 := defaultUser()
+		// u2 has same phone as u1
+		u2 := &user.User{
+			UserID: "user-2", AppID: "app-1",
+			Email: "bob@example.com", Phone: "+15551234567",
+			Preferences: user.Preferences{
+				SMSEnabled: boolPtr(true),
+			},
+		}
+		users := map[string]*user.User{u1.UserID: u1, u2.UserID: u2}
+		nrepo := &mockNotifRepoBulk{}
+		svc := newBulkServiceForTest(users, defaultApps(), nrepo, nil, nil)
+
+		results, err := svc.SendBulk(context.Background(), notification.BulkSendRequest{
+			AppID:    "app-1",
+			UserIDs:  []string{"user-1", "user-2"},
+			Channel:  notification.ChannelSMS,
+			Priority: notification.PriorityNormal,
+			Title:    "Code",
+			Body:     "Your code is 1234",
+		})
+
+		require.NoError(t, err)
+		assert.Len(t, results, 1, "duplicate phone should be deduplicated")
+	})
+
+	t.Run("invalid channel fails validation", func(t *testing.T) {
+		svc := newBulkServiceForTest(defaultUsers(), defaultApps(), nil, nil, nil)
+
+		_, err := svc.SendBulk(context.Background(), notification.BulkSendRequest{
+			AppID:    "app-1",
+			UserIDs:  []string{"user-1"},
+			Channel:  notification.Channel("invalid"),
+			Priority: notification.PriorityNormal,
+			Title:    "Hello",
+			Body:     "World",
+		})
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, notification.ErrInvalidChannel)
+	})
+
+	t.Run("all users skipped returns empty results no error", func(t *testing.T) {
+		// All users have DND
+		u := defaultUser()
+		u.Preferences.DND = true
+		users := map[string]*user.User{u.UserID: u}
+		nrepo := &mockNotifRepoBulk{}
+		q := &mockQueueBulk{}
+		svc := newBulkServiceForTest(users, defaultApps(), nrepo, q, nil)
+
+		results, err := svc.SendBulk(context.Background(), notification.BulkSendRequest{
+			AppID:    "app-1",
+			UserIDs:  []string{"user-1"},
+			Channel:  notification.ChannelEmail,
+			Priority: notification.PriorityNormal,
+			Title:    "Hello",
+			Body:     "World",
+		})
+
+		require.NoError(t, err)
+		assert.Len(t, results, 0)
+		assert.Len(t, q.batch, 0)
+	})
+}


### PR DESCRIPTION
## Changes

### MediaURL Support for Bulk Send
- Added MediaURL field to BulkSendRequest and corresponding DTO
- Removed required validation from Title/Body to allow content_sid and media_url as valid content alternatives
- Promote data.media_url to Content.MediaURL in SendBulk()

### Unit Tests (111 total)
- SendBulk (25 tests): validation errors, content_sid/media_url acceptance, user filtering (DND, missing phone/email, channel disabled, daily limit), dedup, metadata, scheduling, queue/repo failures
- All remaining methods (63 tests): Get, List, Count, UpdateStatus, Cancel, CancelBatch, Retry, FlushQueued, GetUnreadCount, MarkRead, ListUnread, Snooze, Unsnooze, Archive, MarkAllRead, ListSnoozedDue, SendBatch, isChannelEnabled
- Combined with existing Send tests (23), total coverage is 111 unit tests for NotificationService

### Files Changed
- internal/domain/notification/models.go - MediaURL field + validation updates
- internal/interfaces/http/dto/notification_dto.go - DTO MediaURL field + mapping
- internal/usecases/notification_service.go - MediaURL promotion in SendBulk
- internal/usecases/notification_service_send_test.go - 25 SendBulk tests
- internal/usecases/notification_service_methods_test.go - 63 method-level tests (new file)
