### PR TITLE
Dispatch release-cli workflow after auto version bump

### DIFF
--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -10,6 +10,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write  # needed to dispatch the release-cli workflow after tagging
 
 jobs:
   release:
@@ -19,9 +20,24 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Bump version on PR merge with labels
+        id: bumpr
         uses: haya14busa/action-bumpr@v1
         with:
           github_token: ${{ github.token }}
           default_bump_level: patch
           tag_as_user: "GitHub Action"
           tag_as_email: "action@github.com"
+
+      # The tag created above is pushed with GITHUB_TOKEN, which by GitHub
+      # design does NOT trigger downstream workflows (prevents loops). So we
+      # explicitly dispatch the release-cli workflow with the new tag.
+      # workflow_dispatch via the API is allowed with GITHUB_TOKEN + actions:write,
+      # so no PAT is required.
+      - name: Trigger CLI release build
+        if: github.event_name == 'push' && steps.bumpr.outputs.skip != 'true' && steps.bumpr.outputs.next_version != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEW_TAG: ${{ steps.bumpr.outputs.next_version }}
+        run: |
+          echo "Dispatching release-cli.yml for tag $NEW_TAG"
+          gh workflow run release-cli.yml --ref main -f "tag=$NEW_TAG"


### PR DESCRIPTION
GitHub does not trigger downstream workflows when a tag is pushed using GITHUB_TOKEN (anti-loop safety). As a result release-cli.yml never fired on the v1.0.7 tag created during the PR #107 merge.

Fix: after action-bumpr creates the tag, explicitly dispatch release-cli.yml with the new tag via 'gh workflow run'. workflow_dispatch via the REST API is permitted with GITHUB_TOKEN + actions:write, so no PAT is required.

Gated on github.event_name == 'push' so PR-labeled dry runs do not trigger releases.