### PR TITLE
Rich interactive messaging (templates, carousel, click attribution, Twilio + Meta runtime)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -32,10 +32,23 @@ worker.exe
 *.swo
 *~
 
-# Environment
+# Environment - never bake secrets into the image. Multi-stage build already
+# discards the builder layer, but defense in depth: don't even let .env reach
+# the build context.
 .env
-.env.local
-.env.*.local
+.env.*
+**/.env
+**/.env.*
+!**/.env.example
+*.pem
+*.key
+*.crt
+secrets/
+
+# Production deployment artifacts (compose + prod env live on the host, not
+# in the image).
+prod/
+deploy/
 
 # Logs
 *.log

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -41,6 +41,8 @@ var allIndices = []string{
 	"credit_ledger",
 	"billing_rate_cards",
 	"billing_runtime",
+	// WhatsApp rich templates (Phase 0 of WHATSAPP_RICH_INTERACTIVE_PLAN.md)
+	"whatsapp_rich_templates",
 }
 
 var rootCmd = &cobra.Command{

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/the-monkeys/freerangenotify/internal/infrastructure/queue"
 	"github.com/the-monkeys/freerangenotify/internal/infrastructure/repository"
 	"github.com/the-monkeys/freerangenotify/internal/telemetry"
+	"github.com/the-monkeys/freerangenotify/internal/usecases/services"
 	"go.uber.org/zap"
 )
 
@@ -330,6 +331,23 @@ func main() {
 		processor.SetSubscriberThrottle(subscriberThrottle)
 		logger.Info("Subscriber throttle enabled")
 	}
+
+	// ── WhatsApp Rich Templates: runtime resolver ──
+	// The worker needs read-only access to rich templates to expand
+	// notification.Content.Data["whatsapp_rich"]["template_id"] into the
+	// provider-specific wire shape. apiVersion/metaApp credentials are
+	// unused for resolution and left empty intentionally — authoring
+	// (Create/Sync) runs in the API server. See
+	// WHATSAPP_RICH_INTERACTIVE_PLAN.md §4.2.
+	richTplRepo := repository.NewWhatsAppRichTemplateRepository(c.DatabaseManager.Client.GetClient(), logger)
+	richTplSvc := services.NewWhatsAppRichTemplateService(
+		richTplRepo,
+		c.DatabaseManager.Repositories.Application,
+		nil, "", "", "",
+		logger,
+	)
+	processor.SetWhatsAppRichTemplateService(richTplSvc)
+	logger.Info("WhatsApp rich-template resolver wired into worker")
 
 	// Wait for shutdown signal
 	sigChan := make(chan os.Signal, 1)

--- a/cmd/worker/processor.go
+++ b/cmd/worker/processor.go
@@ -21,6 +21,7 @@ import (
 	"github.com/the-monkeys/freerangenotify/internal/domain/notification"
 	"github.com/the-monkeys/freerangenotify/internal/domain/template"
 	"github.com/the-monkeys/freerangenotify/internal/domain/user"
+	"github.com/the-monkeys/freerangenotify/internal/domain/whatsapp"
 	"github.com/the-monkeys/freerangenotify/internal/infrastructure/limiter"
 	"github.com/the-monkeys/freerangenotify/internal/infrastructure/metrics"
 	"github.com/the-monkeys/freerangenotify/internal/infrastructure/orchestrator"
@@ -64,8 +65,9 @@ type NotificationProcessor struct {
 	logger           *zap.Logger
 	config           ProcessorConfig
 	metrics          *metrics.NotificationMetrics
-	digestManager    *orchestrator.DigestManager // Phase 1: optional digest support
-	throttle         *limiter.SubscriberThrottle // Phase 2: optional per-subscriber throttle
+	digestManager    *orchestrator.DigestManager          // Phase 1: optional digest support
+	throttle         *limiter.SubscriberThrottle          // Phase 2: optional per-subscriber throttle
+	richTplService   services.WhatsAppRichTemplateService // WhatsApp rich-template runtime resolver
 
 	wg       sync.WaitGroup
 	stopChan chan struct{}
@@ -80,6 +82,15 @@ func (p *NotificationProcessor) SetDigestManager(dm *orchestrator.DigestManager)
 // SetSubscriberThrottle injects the optional subscriber throttle (Phase 2).
 func (p *NotificationProcessor) SetSubscriberThrottle(t *limiter.SubscriberThrottle) {
 	p.throttle = t
+}
+
+// SetWhatsAppRichTemplateService injects the optional WhatsApp rich-template
+// runtime resolver. When set, the processor expands
+// notification.Content.Data["whatsapp_rich"]["template_id"] into the
+// provider-specific wire shape just before WhatsApp dispatch.
+// See WHATSAPP_RICH_INTERACTIVE_PLAN.md §4.2 / §5.2.
+func (p *NotificationProcessor) SetWhatsAppRichTemplateService(svc services.WhatsAppRichTemplateService) {
+	p.richTplService = svc
 }
 
 // NewNotificationProcessor creates a new notification processor
@@ -931,6 +942,13 @@ func (p *NotificationProcessor) sendNotification(ctx context.Context, notif *not
 	//   2. app.Settings.WhatsApp.Provider == "meta" => "meta_whatsapp"
 	//   3. otherwise => Twilio "whatsapp" (system credentials or Twilio BYOC)
 	if notif.Channel == notification.ChannelWhatsApp {
+		// Resolve FRN rich-template runtime payload BEFORE provider routing.
+		// When whatsapp_rich.template_id is present, expand it into the
+		// provider-specific wire shape so the chosen provider's renderer
+		// has everything it needs. See WHATSAPP_RICH_INTERACTIVE_PLAN §4.2.
+		if p.richTplService != nil {
+			p.resolveWhatsAppRich(ctx, notif, app)
+		}
 		waProviderChain := []string{"whatsapp", "meta_whatsapp"}
 		if notif.Content.Data != nil {
 			if sid, _ := notif.Content.Data["content_sid"].(string); sid != "" {
@@ -1417,6 +1435,87 @@ func (p *NotificationProcessor) renderTemplate(tmplStr string, data map[string]i
 		zap.String("result", result))
 
 	return result, nil
+}
+
+// resolveWhatsAppRich expands notification.Content.Data["whatsapp_rich"]
+// into the provider-specific wire shape:
+//
+//   - Meta path: replaces "whatsapp_rich" with a resolved interactive/template
+//     payload that meta_whatsapp_provider.buildRichMessage understands.
+//   - Twilio path: lifts content_sid + content_variables into Content.Data
+//     and removes "whatsapp_rich" so the existing Twilio code path renders.
+//
+// This runs once per notification, just before WhatsApp provider chain
+// selection. Errors are logged but non-fatal: the provider will surface a
+// proper validation error if the resulting payload is unusable.
+func (p *NotificationProcessor) resolveWhatsAppRich(ctx context.Context, notif *notification.Notification, app *application.Application) {
+	if notif == nil || notif.Content.Data == nil {
+		return
+	}
+	raw, ok := notif.Content.Data["whatsapp_rich"]
+	if !ok {
+		return
+	}
+	rawMap, ok := raw.(map[string]interface{})
+	if !ok {
+		return
+	}
+	tplID, _ := rawMap["template_id"].(string)
+	if tplID == "" {
+		return
+	}
+
+	// Re-encode through JSON to honour json-tag-driven decoding into the
+	// strongly-typed SendPayload. This is robust against arbitrary nested
+	// shapes coming off the queue.
+	buf, err := json.Marshal(rawMap)
+	if err != nil {
+		p.logger.Warn("whatsapp_rich: failed to marshal payload", zap.Error(err))
+		return
+	}
+	var payload whatsapp.SendPayload
+	if err := json.Unmarshal(buf, &payload); err != nil {
+		p.logger.Warn("whatsapp_rich: failed to decode SendPayload", zap.Error(err))
+		return
+	}
+	if payload.TemplateID == "" {
+		return
+	}
+
+	provider := ""
+	if app != nil && app.Settings.WhatsApp != nil {
+		provider = strings.ToLower(strings.TrimSpace(app.Settings.WhatsApp.Provider))
+	}
+
+	switch provider {
+	case "meta":
+		resolved, err := p.richTplService.ResolveSendPayload(ctx, notif.AppID, notif.NotificationID, payload)
+		if err != nil {
+			p.logger.Error("whatsapp_rich: meta resolution failed",
+				zap.String("notification_id", notif.NotificationID),
+				zap.String("template_id", payload.TemplateID),
+				zap.Error(err))
+			return
+		}
+		notif.Content.Data["whatsapp_rich"] = resolved
+	default:
+		// Twilio (or system) — flatten to content_sid + content_variables.
+		resolved, err := p.richTplService.ResolveTwilioSendPayload(ctx, notif.AppID, notif.NotificationID, payload)
+		if err != nil {
+			p.logger.Error("whatsapp_rich: twilio resolution failed",
+				zap.String("notification_id", notif.NotificationID),
+				zap.String("template_id", payload.TemplateID),
+				zap.Error(err))
+			return
+		}
+		if sid, ok := resolved["content_sid"].(string); ok && sid != "" {
+			notif.Content.Data["content_sid"] = sid
+		}
+		if vars, ok := resolved["content_variables"]; ok {
+			notif.Content.Data["content_variables"] = vars
+		}
+		delete(notif.Content.Data, "whatsapp_rich")
+	}
 }
 
 // hasValidEmailConfig returns true if the app has explicitly configured and complete

--- a/docs/openapi/whatsapp-rich.yaml
+++ b/docs/openapi/whatsapp-rich.yaml
@@ -1,0 +1,359 @@
+# WhatsApp Rich Templates — OpenAPI Fragment
+#
+# Drop-in OpenAPI 3.0 fragment documenting the WhatsApp rich-template
+# authoring + delivery surfaces introduced by
+# documents/plans/WHATSAPP_RICH_INTERACTIVE_PLAN.md. This is a stand-alone
+# file (not merged into docs/openapi/swagger.yaml) so it can be reviewed
+# independently and consumed by Swagger UI via $ref includes.
+#
+# Endpoints documented:
+#   POST   /v1/whatsapp/rich-templates           — create + submit to Meta/Twilio
+#   GET    /v1/whatsapp/rich-templates           — list (paginated)
+#   GET    /v1/whatsapp/rich-templates/{id}      — fetch one
+#   DELETE /v1/whatsapp/rich-templates/{id}      — soft-delete
+#   POST   /v1/whatsapp/rich-templates/{id}/sync — refresh approval state
+#   POST   /v1/whatsapp/rich-templates/{id}/preview — render with variables
+#   GET    /v1/r/{sig}                           — public click-attribution redirect
+#   POST   /v1/webhooks/twilio/content-status    — Twilio approval webhook
+#   POST   /v1/webhooks/twilio/whatsapp          — Twilio inbound webhook
+openapi: 3.0.3
+info:
+  title: FreeRangeNotify — WhatsApp Rich Templates
+  version: "1.0.0"
+  description: |
+    Typed authoring + delivery for WhatsApp interactive messages
+    (carousel, coupon-code, single-product, multi-product, catalog).
+
+servers:
+  - url: http://localhost:8080/v1
+    description: Local development
+
+security:
+  - ApiKeyAuth: []
+
+paths:
+  /whatsapp/rich-templates:
+    post:
+      summary: Create a rich template
+      description: |
+        Validates the template, submits it to every configured provider
+        (Meta Cloud API and/or Twilio Content API), and persists the
+        resulting bindings. Meta failures are returned as 400 so the
+        author sees rejection reasons immediately; Twilio submission is
+        best-effort and can be reconciled later via the sync endpoint.
+      operationId: createRichTemplate
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/RichTemplate" }
+      responses:
+        "200":
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data: { $ref: "#/components/schemas/RichTemplate" }
+        "400":
+          $ref: "#/components/responses/ValidationError"
+    get:
+      summary: List rich templates
+      operationId: listRichTemplates
+      parameters:
+        - in: query
+          name: kind
+          schema:
+            type: string
+            enum: [carousel, coupon_code, product, multi_product, catalog, list_message, location_request, flow]
+        - in: query
+          name: status
+          schema:
+            type: string
+            enum: [draft, pending, approved, partially_submitted, rejected, disabled]
+        - in: query
+          name: limit
+          schema: { type: integer, default: 50 }
+        - in: query
+          name: offset
+          schema: { type: integer, default: 0 }
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items: { $ref: "#/components/schemas/RichTemplate" }
+                  total: { type: integer }
+
+  /whatsapp/rich-templates/{id}:
+    parameters:
+      - { in: path, name: id, required: true, schema: { type: string } }
+    get:
+      summary: Fetch a rich template by id
+      operationId: getRichTemplate
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data: { $ref: "#/components/schemas/RichTemplate" }
+        "404": { $ref: "#/components/responses/NotFound" }
+    delete:
+      summary: Soft-delete a rich template
+      operationId: deleteRichTemplate
+      responses:
+        "204": { description: Deleted }
+
+  /whatsapp/rich-templates/{id}/sync:
+    post:
+      summary: Re-fetch provider approval state
+      description: |
+        Polls Meta (and Twilio if bound) for the latest approval status
+        and updates the stored bindings. Useful when the provider's
+        async approval webhook was missed or replayed.
+      operationId: syncRichTemplate
+      parameters:
+        - { in: path, name: id, required: true, schema: { type: string } }
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data: { $ref: "#/components/schemas/RichTemplate" }
+
+  /whatsapp/rich-templates/{id}/preview:
+    post:
+      summary: Render a template with variables (read-only preview)
+      operationId: previewRichTemplate
+      parameters:
+        - { in: path, name: id, required: true, schema: { type: string } }
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                variables:
+                  type: object
+                  additionalProperties: { type: string }
+      responses:
+        "200":
+          description: Rendered provider payload (Meta wire-format)
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+
+  /r/{sig}:
+    get:
+      summary: Click-attribution redirect (public)
+      description: |
+        Verifies a signed click payload, records an analytics event, and
+        302-redirects to the original URL. This endpoint is intentionally
+        outside the API key auth group so WhatsApp recipients can follow
+        button links without credentials.
+      security: []
+      operationId: clickRedirect
+      parameters:
+        - { in: path, name: sig, required: true, schema: { type: string } }
+      responses:
+        "302":
+          description: Redirect to original URL
+          headers:
+            Location: { schema: { type: string, format: uri } }
+        "400": { description: Invalid or expired signature }
+
+  /webhooks/twilio/content-status:
+    post:
+      summary: Twilio Content API approval webhook
+      description: |
+        Receives Twilio's approval status updates (approved / rejected /
+        disabled) for Content templates created via this app. Always
+        returns 200 to prevent retries. Signature is validated via
+        X-Twilio-Signature when an auth token is configured.
+      security: []
+      operationId: twilioContentStatusWebhook
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required: [ContentSid, Status]
+              properties:
+                ContentSid: { type: string }
+                Status:
+                  type: string
+                  enum: [approved, pending, rejected, disabled]
+                RejectionReason: { type: string }
+      responses:
+        "200": { description: Acknowledged }
+
+  /webhooks/twilio/whatsapp:
+    post:
+      summary: Twilio inbound WhatsApp webhook
+      description: |
+        Receives inbound replies, button taps, and list selections from
+        Twilio's Programmable Messaging webhook. Resolves the target FRN
+        app by matching the `To` number against
+        application.Settings.WhatsApp.FromNumber and forwards a
+        normalised InboundMessage to the WhatsApp service, which in turn
+        emits `whatsapp.button_clicked` / `whatsapp.list_selected` /
+        `whatsapp.text_received` workflow events.
+      security: []
+      operationId: twilioInboundWhatsAppWebhook
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                MessageSid: { type: string }
+                From: { type: string, example: "whatsapp:+14155550100" }
+                To: { type: string, example: "whatsapp:+14155551234" }
+                Body: { type: string }
+                ButtonText: { type: string }
+                ButtonPayload: { type: string }
+                ListId: { type: string }
+                OriginalRepliedMessageSid: { type: string }
+      responses:
+        "200": { description: Acknowledged }
+        "403": { description: Invalid X-Twilio-Signature }
+
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key
+
+  responses:
+    ValidationError:
+      description: Validation failed
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error: { type: string }
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    field: { type: string }
+                    msg: { type: string }
+    NotFound:
+      description: Resource not found
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error: { type: string }
+
+  schemas:
+    RichTemplate:
+      type: object
+      required: [kind, name]
+      properties:
+        id: { type: string, readOnly: true }
+        tenant_id: { type: string, readOnly: true }
+        app_id: { type: string, readOnly: true }
+        kind:
+          type: string
+          enum: [carousel, coupon_code, product, multi_product, catalog, list_message, location_request, flow]
+        name:
+          type: string
+          description: Provider template name (snake_case, 1–512 chars).
+        language: { type: string, example: en_US }
+        category:
+          type: string
+          enum: [MARKETING, UTILITY, AUTHENTICATION]
+        body: { type: string }
+        footer: { type: string }
+        coupon_code: { type: string, description: Only used when kind=coupon_code }
+        cards:
+          type: array
+          description: Required when kind=carousel (2–10 cards).
+          items: { $ref: "#/components/schemas/CarouselCard" }
+        variables:
+          type: array
+          items: { type: string }
+          description: |
+            Declared variable keys (e.g. ["1","2"]). Used at send-time to
+            decide which fields are template-driven vs caller-controlled.
+        providers: { $ref: "#/components/schemas/ProviderBindings" }
+        created_at: { type: string, format: date-time, readOnly: true }
+        updated_at: { type: string, format: date-time, readOnly: true }
+
+    CarouselCard:
+      type: object
+      properties:
+        header_image_url: { type: string, format: uri }
+        header_video_url: { type: string, format: uri }
+        body: { type: string }
+        buttons:
+          type: array
+          items: { $ref: "#/components/schemas/Button" }
+
+    Button:
+      type: object
+      required: [type, text]
+      properties:
+        type:
+          type: string
+          enum: [URL, QUICK_REPLY, PHONE_NUMBER, COPY_CODE, CATALOG, MPM, FLOW]
+        text: { type: string }
+        url: { type: string }
+        phone_number: { type: string }
+        payload: { type: string }
+        track_clicks:
+          type: boolean
+          description: |
+            When true and a click signer is configured, URL buttons are
+            wrapped with a signed /v1/r/{sig} redirect so taps appear in
+            the analytics index.
+
+    ProviderBindings:
+      type: object
+      properties:
+        meta: { $ref: "#/components/schemas/MetaBinding" }
+        twilio: { $ref: "#/components/schemas/TwilioBinding" }
+
+    MetaBinding:
+      type: object
+      properties:
+        template_id: { type: string, description: Meta-side template ID }
+        status:
+          type: string
+          enum: [pending, approved, rejected, disabled]
+        rejection_reason: { type: string }
+        submitted_at: { type: string, format: date-time }
+        last_synced_at: { type: string, format: date-time }
+
+    TwilioBinding:
+      type: object
+      properties:
+        content_sid: { type: string, example: HX1234567890abcdef }
+        status:
+          type: string
+          enum: [pending, approved, rejected, disabled]
+        rejection_reason: { type: string }
+        submitted_at: { type: string, format: date-time }
+        last_synced_at: { type: string, format: date-time }

--- a/documents/API_DOCUMENTATION.md
+++ b/documents/API_DOCUMENTATION.md
@@ -650,3 +650,80 @@ const params = {
 await client.notifications.send(params);
 ```
 
+---
+
+## WhatsApp Rich Templates
+
+See [docs/openapi/whatsapp-rich.yaml](../docs/openapi/whatsapp-rich.yaml) for the full OpenAPI fragment covering authoring, sync, preview, click attribution, and Twilio webhooks.
+
+### Authoring
+
+`POST /v1/whatsapp/rich-templates` validates a typed template, submits it to every configured provider (Meta Cloud API and/or Twilio Content API), and persists the resulting bindings. Meta failures return 400 with the rejection reason; Twilio submission is best-effort and reconciled via the sync endpoint.
+
+Example carousel payload:
+
+```json
+{
+  "kind": "carousel",
+  "name": "diwali_carousel",
+  "language": "en_US",
+  "body": "Hi {{1}}, check these out:",
+  "cards": [
+    {
+      "header_image_url": "https://cdn.example.com/p1.jpg",
+      "body": "Trendy Polo {{1}}",
+      "buttons": [
+        { "type": "URL", "text": "Shop", "url": "https://shop.example/p/{{1}}", "track_clicks": true }
+      ]
+    },
+    {
+      "header_image_url": "https://cdn.example.com/p2.jpg",
+      "body": "Classic Shirt {{1}}",
+      "buttons": [
+        { "type": "URL", "text": "Shop", "url": "https://shop.example/p/{{1}}", "track_clicks": true }
+      ]
+    }
+  ]
+}
+```
+
+### Listing, sync, preview
+
+- `GET /v1/whatsapp/rich-templates?kind=carousel&status=approved&limit=50` — paginated list.
+- `POST /v1/whatsapp/rich-templates/{id}/sync` — re-fetch provider approval state.
+- `POST /v1/whatsapp/rich-templates/{id}/preview` — render with a `variables` map, returns Meta wire-format JSON for inspection.
+
+### Sending
+
+Reference an approved rich template from any send path by attaching the typed payload to `data.whatsapp_rich`. When this object carries a `template_id`, `content_sid` is not required on the request:
+
+```json
+{
+  "channel": "whatsapp",
+  "user_id": "user-internal-uuid",
+  "data": {
+    "whatsapp_rich": {
+      "template_id": "rich-tpl-abc123",
+      "variables": { "1": "Asha" },
+      "cards": [
+        { "variables": { "1": "Polo" },  "button_values": ["polo-sku"] },
+        { "variables": { "1": "Shirt" }, "button_values": ["shirt-sku"] }
+      ]
+    }
+  }
+}
+```
+
+The worker resolves `template_id` against the configured provider before dispatch:
+
+- **Meta path**: `whatsapp_rich` is expanded into the provider's interactive/template JSON.
+- **Twilio path**: `whatsapp_rich` is flattened into `content_sid` + `content_variables`, with carousel per-card overrides emitted as `<card_index>.<position>` keys (1-indexed).
+
+### Click attribution
+
+Buttons with `track_clicks: true` are wrapped at render-time with a signed `/v1/r/{sig}` redirect so taps land in the analytics index. `server.public_url` must be set for wrapping to take effect — when it is empty, URLs degrade to pass-through and a warning is logged at boot.
+
+### Twilio webhooks
+
+- `POST /v1/webhooks/twilio/content-status` — Twilio Content API approval updates. The handler maps `ContentSid` → FRN-side `TwilioBinding` via the rich-template service. Always returns 200 to prevent retries.
+- `POST /v1/webhooks/twilio/whatsapp` — Twilio Programmable Messaging inbound webhook for replies, button taps, and list selections. Resolves the target FRN app by matching `To` against `application.Settings.WhatsApp.FromNumber`, then forwards a normalised `InboundMessage` to the WhatsApp service which emits `whatsapp.button_clicked` / `whatsapp.list_selected` / `whatsapp.text_received` workflow events. Signature is verified against `providers.whatsapp.auth_token` when configured; requests with a bad signature are rejected with `403`.

--- a/documents/META_APP_REVIEW_VIDEO_SCRIPT.md
+++ b/documents/META_APP_REVIEW_VIDEO_SCRIPT.md
@@ -1,0 +1,130 @@
+# Meta App Review — Video Scripts for Quick Approval
+
+For: FreeRangeNotify (Tech Provider app `828282083012160`)
+Targets: `whatsapp_business_messaging` + `whatsapp_business_management` (Advanced access)
+
+Meta needs **two short screen recordings** (no voiceover required; on-screen text is fine).
+Keep each video **45–90 seconds**. Do everything in **one continuous take per video** — no cuts.
+Use a clean Chrome window in incognito so the URL bar is uncluttered.
+
+---
+
+## Pre-recording checklist (do this once, then record both videos back to back)
+
+1. Local stack is up: `docker compose up -d` and ngrok is running.
+2. UI is open at `https://www.freerangenotify.com/` (or your ngrok URL — must be HTTPS).
+3. You are logged in as an admin user.
+4. The WABA is **already connected** (Connected badge visible in the WhatsApp tab). The reviewer is not approving the connect flow — they are approving the *send* and *manage templates* flows.
+5. You have a second device with WhatsApp installed, ready to receive the test message. Use a number that is **registered as a test recipient** in App Dashboard → WhatsApp → API Setup (so you don't need an approved template to send).
+6. Recording tool: OBS, Loom, or Windows Game Bar (`Win+G`). Resolution 1280×720 or higher.
+
+---
+
+## Video 1 — “Send a message from the app and receive it on a phone”
+
+**Duration target: 60–75 seconds.**
+
+### Script (what you do on screen, in order)
+
+| # | Action on screen | On-screen caption to add (optional) |
+|---|------------------|-------------------------------------|
+| 1 | Show the browser URL bar so reviewer sees the FRN dashboard URL. | *“FreeRangeNotify dashboard — Tech Provider app for WhatsApp.”* |
+| 2 | Click **Applications** → click into **Release Test App**. | *“Select a tenant application.”* |
+| 3 | Click the **WhatsApp** tab. Pause 1 second on the green “Connected” card so the reviewer can read the **WABA ID** and **Phone** clearly. | *“This tenant is connected to a real Meta WABA.”* |
+| 4 | Click **Quick Send** in the sidebar (or the “Send Message” button in the WhatsApp tab — whichever is visible). | — |
+| 5 | In the recipient field, type the **test phone number on your second device** (E.164 format, e.g. `+919876543210`). | — |
+| 6 | In the message body, type: `Hello from FreeRangeNotify App Review test`. | *“Composing a freeform session message.”* |
+| 7 | Click **Send**. Show the success toast / delivery status changing from `queued` → `sent` → `delivered`. | *“Message sent via Meta WhatsApp Cloud API.”* |
+| 8 | **Tab away from the browser to your phone screen** (or place your phone in front of the webcam). Show the WhatsApp chat where the message just arrived, with the **timestamp matching the send time**. Hold the phone steady for 3 seconds. | *“Message received in WhatsApp client.”* |
+| 9 | (Optional but strong) Reply from the phone with `Got it 👍`. Tab back to the browser, open **Inbox**, show the inbound message appearing. | *“Two-way messaging working via webhook.”* |
+
+### Why this satisfies the requirement
+Meta's [Tech Provider checklist](https://developers.facebook.com/documentation/business-messaging/whatsapp/solution-providers/get-started-for-tech-providers) says verbatim:
+
+> The first video must show a message created and sent from your app and received in the WhatsApp client (mobile app or web app).
+
+Steps 5–8 cover exactly that. Step 9 is bonus credit that demonstrates inbound webhook handling, which strengthens the case for `whatsapp_business_messaging` Advanced access.
+
+---
+
+## Video 2 — “Create a message template from the app”
+
+**Duration target: 45–60 seconds.**
+
+### Script
+
+| # | Action on screen | On-screen caption to add (optional) |
+|---|------------------|-------------------------------------|
+| 1 | Still inside **Release Test App** → **WhatsApp** tab. Scroll to **WhatsApp Rich Templates** (the section we built — *not* the Twilio one). | *“Authoring a Meta WhatsApp message template.”* |
+| 2 | Click **+ New Template** (or whichever button opens the builder). | — |
+| 3 | Fill these fields in front of the camera (type slowly so the reviewer can read): <br>• **Name:** `review_demo_welcome` <br>• **Language:** `en_US` <br>• **Category:** `MARKETING` <br>• **Kind:** `Coupon Code` <br>• **Body:** `Hi {{1}}, welcome to {{2}}. Use code {{3}} for 10% off.` <br>• **Coupon code:** `WELCOME10` | *“Filling out template content with three variables and a copy-code button.”* |
+| 4 | Click **Create** (or **Submit for Approval**). Wait for the toast. | *“Template created in FRN and submitted to Meta Graph API.”* |
+| 5 | The template appears in the list with a **PENDING / In Review** badge from Meta and the Meta template ID visible. Hover/click to expand and show the Meta binding (`meta_template_id`, `category`, `language`). Hold for 3 seconds. | *“Template registered with Meta WABA and awaiting approval.”* |
+| 6 | (Optional) Open a second tab to https://business.facebook.com/wa/manage/message-templates/ and show the same template name appearing in **WhatsApp Manager** with status “In review”. This is the strongest possible evidence. | *“Same template visible in Meta’s WhatsApp Manager — proves our API call hit the real WABA.”* |
+
+### Why this satisfies the requirement
+Meta says:
+
+> The second video must show your app being used to create a message template.
+
+Steps 3–5 satisfy it directly. Step 6 is the optional "screen recording of WhatsApp Manager" alternative — including it inside the same video doubles the proof and removes any reviewer doubt that the call was real.
+
+---
+
+## Voiceover script (optional — use only if you want to narrate)
+
+Keep it neutral, factual, no marketing language. Read in a normal speaking pace.
+
+> "This is FreeRangeNotify, a Tech Provider application for the WhatsApp Business Platform. In this clip I am sending a session message from our dashboard to a test WhatsApp number. The message reaches the WhatsApp client on the receiving device. In the second clip I create a Marketing-category message template with a copy-code button, which is submitted to the WhatsApp Business Account via the Meta Graph API and appears in WhatsApp Manager pending approval."
+
+That single paragraph is enough for both videos combined.
+
+---
+
+## Submission form — text answers Meta will ask for
+
+When you click **Submit App Review**, Meta asks for one paragraph per permission. Use these.
+
+### `whatsapp_business_messaging`
+
+> FreeRangeNotify uses `whatsapp_business_messaging` to send session and template messages on behalf of our onboarded business customers via the Cloud API endpoint `/{phone_number_id}/messages`. The first attached video shows a user composing and sending a message from our dashboard which is delivered to a real WhatsApp client. We also use this permission to receive inbound message webhooks (`messages`, `statuses`) and surface them in the customer's Inbox.
+
+### `whatsapp_business_management`
+
+> FreeRangeNotify uses `whatsapp_business_management` to create, list, and delete message templates on behalf of our onboarded business customers via `/{waba_id}/message_templates`, and to subscribe our public webhook callback URL via `/{waba_id}/subscribed_apps`. The second attached video shows a user authoring a `MARKETING` template with three variables and a `COPY_CODE` button, which is submitted to the customer's WABA and appears in WhatsApp Manager pending approval.
+
+### App icon, privacy policy, terms of service (Basic settings)
+
+| Field | Value |
+|-------|-------|
+| App icon | 1024×1024 PNG of your FRN logo on solid background |
+| Privacy policy URL | https://www.freerangenotify.com/privacy |
+| Terms of service URL | https://www.freerangenotify.com/terms |
+| Category | Business |
+| Data deletion URL | https://www.freerangenotify.com/data-deletion |
+
+If any of those URLs don't exist yet, **create them before submitting** — Meta auto-rejects on day one if they 404.
+
+---
+
+## Common rejection reasons and how to avoid them
+
+1. **Video is too short or cuts mid-action.** → 45 sec minimum, one continuous take.
+2. **Reviewer can't see the message arrive on the phone.** → Always pan/cut to the phone for at least 3 seconds with the timestamp visible.
+3. **You demoed on a Tester account but the app is in Live mode.** → Don't matter, but make sure the receiving number is registered as a test recipient *or* the template you use is already approved.
+4. **The template video shows authoring without actually submitting to Meta.** → Always click Submit and show the PENDING state. Bonus: open WhatsApp Manager in a second tab.
+5. **App is missing Business Verification.** → Verify the business *first*; App Review will not start otherwise.
+6. **Privacy policy URL 404s.** → Half of all first-attempt rejections.
+
+---
+
+## After approval
+
+Once both permissions are approved:
+
+1. Meta App Dashboard → top header → flip **App Mode** to **Live**.
+2. Webhook callback URL must be a stable HTTPS endpoint (not ngrok). Move to your prod domain.
+3. Your `/v1/admin/whatsapp/connect` Embedded Signup flow now works for any Facebook user, not just app testers.
+4. Remove the "Use a System User access token instead" UI fallback if you don't want self-serve customers to see it (it still works for self-hosted deployments).
+
+Estimated turnaround: **2–5 business days** for a clean submission, longer if your business verification is also pending.

--- a/e2e/whatsapp-carousel.spec.ts
+++ b/e2e/whatsapp-carousel.spec.ts
@@ -1,0 +1,99 @@
+/**
+ * WhatsApp Rich Templates — carousel authoring smoke test.
+ *
+ * Verifies the carousel builder POSTs a well-formed RichTemplate to
+ * /v1/whatsapp/rich-templates/ when the user clicks "Submit to Meta".
+ * Network is intercepted so this spec runs without a real Meta binding
+ * and without persisting state into the test app.
+ *
+ * Covers WHATSAPP_RICH_INTERACTIVE_PLAN.md §3 (carousel authoring UI) and
+ * §10 (e2e). Click attribution and runtime resolution are covered by Go
+ * unit tests in internal/usecases/services/whatsapp_rich_template_service_test.go.
+ */
+import { test, expect, captureRequestBody } from './fixtures';
+
+test.describe('WhatsApp Rich Templates', () => {
+    test.beforeEach(async ({ page, state }) => {
+        // Stub list endpoint so the page renders an empty state without
+        // touching the real backend. The order matters: install routes
+        // BEFORE navigation so the very first XHR is intercepted.
+        await page.route('**/v1/whatsapp/rich-templates/**', async (route) => {
+            const req = route.request();
+            if (req.method() === 'GET') {
+                await route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body: JSON.stringify({ data: [], total: 0 }),
+                });
+                return;
+            }
+            if (req.method() === 'POST') {
+                // Echo back a fake RichTemplate so the UI's success path
+                // (toast + refetch) runs without errors.
+                await route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body: JSON.stringify({
+                        data: {
+                            id: 'rich-tpl-test-1',
+                            kind: 'carousel',
+                            name: 'spec_carousel',
+                            language: 'en_US',
+                            providers: {},
+                            created_at: new Date().toISOString(),
+                        },
+                    }),
+                });
+                return;
+            }
+            await route.continue();
+        });
+
+        await page.goto(`/apps/${state.appId}?tab=whatsapp`);
+        // Wait for the rich-templates section heading to confirm the
+        // WhatsApp tab finished mounting before the spec interacts with it.
+        await page
+            .getByRole('heading', { name: 'WhatsApp Rich Templates' })
+            .waitFor({ state: 'visible', timeout: 15_000 });
+    });
+
+    test('creating a carousel posts the expected RichTemplate payload', async ({ page }) => {
+        // Open the builder.
+        await page.getByRole('button', { name: /New Rich Template/i }).click();
+
+        // The form defaults to kind="carousel" with 2 empty cards (§3.1).
+        // Fill template-level fields.
+        await page.locator('input[placeholder="diwali_carousel"]').fill('spec_carousel');
+        await page.locator('input[placeholder="en_US"]').fill('en_US');
+        await page.locator('textarea[placeholder="Hi {{1}}, check these out:"]').fill(
+            'Hi {{1}}, check these carousel picks:',
+        );
+
+        // Fill card 1.
+        const imageInputs = page.locator('input[placeholder="https://cdn.example.com/p1.jpg"]');
+        await imageInputs.nth(0).fill('https://cdn.example.com/p1.jpg');
+        const bodyInputs = page.locator('input[placeholder="Polo {{1}} {{2}}"]');
+        await bodyInputs.nth(0).fill('Trendy Polo {{1}}');
+        const urlInputs = page.locator('input[placeholder="https://shop.example/p/{{1}}"]');
+        await urlInputs.nth(0).fill('https://shop.example/p/{{1}}');
+
+        // Fill card 2.
+        await imageInputs.nth(1).fill('https://cdn.example.com/p2.jpg');
+        await bodyInputs.nth(1).fill('Classic Shirt {{1}}');
+        await urlInputs.nth(1).fill('https://shop.example/p/{{1}}');
+
+        const body = await captureRequestBody(page, '/v1/whatsapp/rich-templates/', async () => {
+            await page.getByRole('button', { name: /Submit to Meta/i }).click();
+        });
+
+        expect(body.kind).toBe('carousel');
+        expect(body.name).toBe('spec_carousel');
+        expect(body.language).toBe('en_US');
+        expect(Array.isArray(body.cards)).toBe(true);
+        // Plan §3: a carousel must carry between 2 and 10 cards.
+        expect((body.cards as unknown[]).length).toBeGreaterThanOrEqual(2);
+        // Per-card body + header image must be present.
+        const firstCard = (body.cards as Array<Record<string, unknown>>)[0];
+        expect(firstCard.body).toBe('Trendy Polo {{1}}');
+    });
+});

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -160,6 +160,16 @@ type Container struct {
 	WhatsAppAdminHandler        *handlers.WhatsAppAdminHandler
 	WhatsAppTemplateHandler     *handlers.WhatsAppTemplateHandler
 	WhatsAppConversationHandler *handlers.WhatsAppConversationHandler
+	// Phase 1 of WHATSAPP_RICH_INTERACTIVE_PLAN.md — typed rich templates.
+	WhatsAppRichTemplateService services.WhatsAppRichTemplateService
+	WhatsAppRichTemplateHandler *handlers.WhatsAppRichTemplateHandler
+	// Phase 2 — Twilio Content API approval webhook.
+	TwilioContentStatusHandler *handlers.TwilioContentStatusHandler
+	// Phase 6 — Twilio inbound WhatsApp (replies / button taps) webhook.
+	TwilioInboundWebhookHandler *handlers.TwilioInboundWebhookHandler
+	// Phase 3 — click attribution.
+	ClickSigner          *whatsapp.ClickSigner
+	ClickRedirectHandler *handlers.ClickRedirectHandler
 
 	// Twilio Content Templates
 	TwilioTemplateHandler *handlers.TwilioTemplateHandler
@@ -742,6 +752,58 @@ func NewContainer(cfg *config.Config, logger *zap.Logger) (*Container, error) {
 			container.WhatsAppService,
 			logger,
 		)
+		// Rich-template authoring (carousel, coupon, cta_url, quick_reply, list)
+		richTplRepo := repository.NewWhatsAppRichTemplateRepository(dbManager.Client.GetClient(), logger)
+		container.WhatsAppRichTemplateService = services.NewWhatsAppRichTemplateService(
+			richTplRepo,
+			repos.Application,
+			nil, // default *http.Client
+			cfg.Providers.MetaWhatsApp.APIVersion,
+			cfg.Providers.MetaWhatsApp.MetaAppID,
+			cfg.Providers.MetaWhatsApp.MetaAppSecret,
+			logger,
+		)
+		container.WhatsAppRichTemplateHandler = handlers.NewWhatsAppRichTemplateHandler(
+			container.WhatsAppRichTemplateService,
+			logger,
+		)
+		container.MetaWebhookHandler.SetRichTemplateService(container.WhatsAppRichTemplateService)
+		container.TwilioContentStatusHandler = handlers.NewTwilioContentStatusHandler(
+			container.WhatsAppRichTemplateService,
+			logger,
+		)
+		// Inbound Twilio WhatsApp webhook (replies, button taps).
+		// Signature validation uses the system-level Twilio auth token; per-app
+		// auth tokens are not currently surfaced to the inbound webhook because
+		// Twilio signs with the account that owns the configured webhook URL,
+		// which in self-hosted FRN is always the system account.
+		if container.WhatsAppService != nil {
+			container.TwilioInboundWebhookHandler = handlers.NewTwilioInboundWebhookHandler(
+				container.WhatsAppService,
+				repos.Application,
+				cfg.Providers.WhatsApp.AuthToken,
+				logger,
+			)
+		}
+		// Click attribution signer + redirect handler (Phase 3). Falls back
+		// to JWTSecret if no dedicated click-signing key is configured.
+		clickKey := cfg.Security.JWTSecret
+		signer, err := whatsapp.NewClickSigner(clickKey)
+		if err != nil {
+			logger.Warn("Click attribution disabled: signer key is empty", zap.Error(err))
+		} else {
+			container.ClickSigner = signer
+			analyticsRepo := repository.NewAnalyticsEventRepository(dbManager.Client.GetClient(), logger)
+			container.ClickRedirectHandler = handlers.NewClickRedirectHandler(signer, analyticsRepo, logger)
+			// Enable click-attribution wrapping in the rich template
+			// service. publicURL is required: log a warning if missing so
+			// operators know why tracked URLs degrade to passthrough.
+			if cfg.Server.PublicURL == "" {
+				logger.Warn("Click attribution: server.public_url is empty; URL buttons with track_clicks will degrade to passthrough")
+			} else if container.WhatsAppRichTemplateService != nil {
+				container.WhatsAppRichTemplateService.EnableClickTracking(signer, cfg.Server.PublicURL)
+			}
+		}
 		logger.Info("WhatsApp Meta integration enabled (webhook receiver, inbound messaging, embedded signup, template management, inbox)")
 	}
 

--- a/internal/domain/notification/models.go
+++ b/internal/domain/notification/models.go
@@ -424,14 +424,21 @@ func (r *BroadcastRequest) Validate() error {
 		return ErrInvalidPriority
 	}
 	// TemplateID required only when NOT triggering a workflow AND NOT using a Twilio Content Template (content_sid)
+	// or an FRN WhatsApp rich template (whatsapp_rich.template_id).
 	if r.WorkflowTriggerID == "" && r.TemplateID == "" {
 		hasContentSID := false
+		hasWhatsAppRichID := false
 		if r.Data != nil {
 			if _, ok := r.Data["content_sid"]; ok {
 				hasContentSID = true
 			}
+			if rich, ok := r.Data["whatsapp_rich"].(map[string]interface{}); ok {
+				if id, _ := rich["template_id"].(string); id != "" {
+					hasWhatsAppRichID = true
+				}
+			}
 		}
-		if !hasContentSID {
+		if !hasContentSID && !hasWhatsAppRichID {
 			return ErrTemplateRequired
 		}
 	}
@@ -563,14 +570,23 @@ func (r *SendRequest) Validate() error {
 		return ErrInvalidPriority
 	}
 	if r.TemplateID == "" && (r.Title == "" || r.Body == "") {
-		// Allow Twilio Content Templates: content_sid in Data is sufficient
+		// Allow Twilio Content Templates: content_sid in Data is sufficient.
+		// Allow FRN WhatsApp rich templates: whatsapp_rich.template_id in Data
+		// (resolved server-side to a Meta template_name and/or Twilio
+		// ContentSid) is also sufficient — see WHATSAPP_RICH_INTERACTIVE_PLAN §5.2.
 		hasContentSID := false
+		hasWhatsAppRichID := false
 		if r.Data != nil {
 			if _, ok := r.Data["content_sid"]; ok {
 				hasContentSID = true
 			}
+			if rich, ok := r.Data["whatsapp_rich"].(map[string]interface{}); ok {
+				if id, _ := rich["template_id"].(string); id != "" {
+					hasWhatsAppRichID = true
+				}
+			}
 		}
-		if !hasContentSID {
+		if !hasContentSID && !hasWhatsAppRichID {
 			return ErrTemplateRequired
 		}
 	}

--- a/internal/domain/whatsapp/click_signer.go
+++ b/internal/domain/whatsapp/click_signer.go
@@ -1,0 +1,133 @@
+package whatsapp
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// ClickPayload is the JSON struct embedded in a signed click-attribution
+// URL. Field names are deliberately one-letter to keep the encoded URL
+// short — these links are sent over WhatsApp where every character costs
+// the user's attention.
+type ClickPayload struct {
+	NotificationID string `json:"n"`
+	AppID          string `json:"a"`
+	ButtonIndex    int    `json:"b"`
+	TargetURL      string `json:"t"`
+	Expiry         int64  `json:"x"` // unix seconds
+}
+
+// ClickSigner builds and verifies signed redirect URLs of the form
+//
+//	{public_url}/v1/r/{base64(payload)}.{hex(hmac(payload))}
+//
+// The HMAC binds the payload to the system signing key (rotated by
+// operators), so an attacker cannot fabricate new redirect targets or
+// extend expiry. The expiry is enforced at verify time.
+type ClickSigner struct {
+	key []byte
+}
+
+// NewClickSigner returns a signer using the provided key. A zero-length
+// key is a hard error to avoid the silent "everything signs to the same
+// HMAC" footgun.
+func NewClickSigner(key string) (*ClickSigner, error) {
+	if key == "" {
+		return nil, errors.New("click signer requires a non-empty signing key")
+	}
+	return &ClickSigner{key: []byte(key)}, nil
+}
+
+// Sign serialises and signs the payload, returning the URL-safe path
+// segment (no leading slash). Callers prepend `{public_url}/v1/r/`.
+func (s *ClickSigner) Sign(p ClickPayload) (string, error) {
+	if p.Expiry == 0 {
+		// Default to 90 days. WhatsApp messages can stay on a phone
+		// effectively forever, but Meta enforces 24h CSW for replies and
+		// most attribution signal value decays inside a week. 90 days
+		// strikes a balance.
+		p.Expiry = time.Now().Add(90 * 24 * time.Hour).Unix()
+	}
+	body, err := json.Marshal(p)
+	if err != nil {
+		return "", err
+	}
+	encoded := base64.RawURLEncoding.EncodeToString(body)
+	mac := s.hmac(encoded)
+	return encoded + "." + mac, nil
+}
+
+// Verify decodes the signed segment, asserts the HMAC and expiry, and
+// returns the payload. Errors are returned as distinct sentinels so
+// handlers can map them to different HTTP responses.
+func (s *ClickSigner) Verify(signed string) (*ClickPayload, error) {
+	dot := -1
+	for i := 0; i < len(signed); i++ {
+		if signed[i] == '.' {
+			dot = i
+			break
+		}
+	}
+	if dot <= 0 || dot >= len(signed)-1 {
+		return nil, ErrClickMalformed
+	}
+	encoded, mac := signed[:dot], signed[dot+1:]
+
+	expected := s.hmac(encoded)
+	if !hmac.Equal([]byte(expected), []byte(mac)) {
+		return nil, ErrClickSignature
+	}
+
+	body, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, ErrClickMalformed
+	}
+	var p ClickPayload
+	if err := json.Unmarshal(body, &p); err != nil {
+		return nil, ErrClickMalformed
+	}
+	if p.Expiry > 0 && time.Now().Unix() > p.Expiry {
+		return nil, ErrClickExpired
+	}
+	if p.TargetURL == "" {
+		return nil, ErrClickMalformed
+	}
+	return &p, nil
+}
+
+// BuildRedirectURL is a convenience that joins the public base URL with
+// the signed path segment. publicURL is expected to be set in
+// cfg.Server.PublicURL (without a trailing slash).
+func (s *ClickSigner) BuildRedirectURL(publicURL string, p ClickPayload) (string, error) {
+	if publicURL == "" {
+		return "", fmt.Errorf("publicURL is required to build click attribution links")
+	}
+	sig, err := s.Sign(p)
+	if err != nil {
+		return "", err
+	}
+	return publicURL + "/v1/r/" + sig, nil
+}
+
+// hmac computes the lowercase-hex HMAC-SHA256 over the encoded payload.
+// Kept private so callers cannot mistakenly hash arbitrary inputs and
+// accidentally generate a valid signature.
+func (s *ClickSigner) hmac(encoded string) string {
+	h := hmac.New(sha256.New, s.key)
+	_, _ = h.Write([]byte(encoded))
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// Sentinel errors returned by Verify so handlers can map them to HTTP
+// status codes (400 vs 410 vs 403) and metrics labels.
+var (
+	ErrClickMalformed = errors.New("click: malformed signed payload")
+	ErrClickSignature = errors.New("click: signature does not match")
+	ErrClickExpired   = errors.New("click: signed payload expired")
+)

--- a/internal/domain/whatsapp/click_signer_test.go
+++ b/internal/domain/whatsapp/click_signer_test.go
@@ -1,0 +1,99 @@
+package whatsapp
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestClickSigner_RoundTrip is the basic happy-path: signing and verifying
+// a payload returns the same fields back.
+func TestClickSigner_RoundTrip(t *testing.T) {
+	s, err := NewClickSigner("test-key-A1")
+	if err != nil {
+		t.Fatalf("NewClickSigner: %v", err)
+	}
+	in := ClickPayload{
+		NotificationID: "n-123",
+		AppID:          "app-X",
+		ButtonIndex:    2,
+		TargetURL:      "https://shop.example.com/p/42",
+	}
+	signed, err := s.Sign(in)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	if !strings.Contains(signed, ".") {
+		t.Errorf("signed string should contain a dot separator: %q", signed)
+	}
+	out, err := s.Verify(signed)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if out.NotificationID != in.NotificationID || out.AppID != in.AppID || out.ButtonIndex != in.ButtonIndex || out.TargetURL != in.TargetURL {
+		t.Errorf("round-trip mismatch: got %+v, want %+v", out, in)
+	}
+}
+
+// TestClickSigner_TamperedSigRejected proves the HMAC actually protects
+// the payload — flipping one byte of the signature makes Verify fail.
+func TestClickSigner_TamperedSigRejected(t *testing.T) {
+	s, _ := NewClickSigner("test-key-A1")
+	signed, _ := s.Sign(ClickPayload{TargetURL: "https://x", NotificationID: "n"})
+
+	tampered := signed[:len(signed)-1] + "0"
+	if tampered == signed {
+		tampered = signed[:len(signed)-1] + "1"
+	}
+	if _, err := s.Verify(tampered); err != ErrClickSignature {
+		t.Errorf("expected ErrClickSignature, got %v", err)
+	}
+}
+
+// TestClickSigner_TamperedPayloadRejected proves you can't swap the
+// payload while keeping the original signature.
+func TestClickSigner_TamperedPayloadRejected(t *testing.T) {
+	s, _ := NewClickSigner("test-key-A1")
+	signed, _ := s.Sign(ClickPayload{TargetURL: "https://x", NotificationID: "n"})
+
+	// Replace the payload portion with a different base64 string but keep
+	// the original signature — should fail HMAC check.
+	dot := strings.Index(signed, ".")
+	tampered := "ZmFrZQ" + signed[dot:]
+	if _, err := s.Verify(tampered); err != ErrClickSignature {
+		t.Errorf("expected ErrClickSignature, got %v", err)
+	}
+}
+
+// TestClickSigner_ExpiredRejected proves the expiry check fires when
+// the signed payload's expiry has passed.
+func TestClickSigner_ExpiredRejected(t *testing.T) {
+	s, _ := NewClickSigner("test-key-A1")
+	signed, _ := s.Sign(ClickPayload{
+		TargetURL:      "https://x",
+		NotificationID: "n",
+		Expiry:         time.Now().Add(-1 * time.Hour).Unix(),
+	})
+	if _, err := s.Verify(signed); err != ErrClickExpired {
+		t.Errorf("expected ErrClickExpired, got %v", err)
+	}
+}
+
+// TestClickSigner_EmptyKeyRejected blocks the silent footgun of an empty
+// signing key (which would otherwise sign every payload identically).
+func TestClickSigner_EmptyKeyRejected(t *testing.T) {
+	if _, err := NewClickSigner(""); err == nil {
+		t.Errorf("expected error for empty key")
+	}
+}
+
+// TestClickSigner_DifferentKeysIndependent proves two signers with
+// different keys cannot validate each other's signatures.
+func TestClickSigner_DifferentKeysIndependent(t *testing.T) {
+	a, _ := NewClickSigner("key-A")
+	b, _ := NewClickSigner("key-B")
+	signed, _ := a.Sign(ClickPayload{TargetURL: "https://x", NotificationID: "n"})
+	if _, err := b.Verify(signed); err != ErrClickSignature {
+		t.Errorf("expected ErrClickSignature, got %v", err)
+	}
+}

--- a/internal/domain/whatsapp/models.go
+++ b/internal/domain/whatsapp/models.go
@@ -31,6 +31,19 @@ type InboundMessage struct {
 	Longitude     float64                `json:"longitude,omitempty" es:"longitude"`
 	RawPayload    map[string]interface{} `json:"raw_payload,omitempty" es:"raw_payload"`
 
+	// Interactive replies and template button taps.
+	// InteractiveType is "button_reply" | "list_reply" | "template_button".
+	// For button_reply / template_button: ReplyID + ReplyTitle (+ Payload for template URL buttons).
+	// For list_reply: ReplyID + ReplyTitle + ReplyDescription.
+	InteractiveType  string `json:"interactive_type,omitempty" es:"interactive_type"`
+	ReplyID          string `json:"reply_id,omitempty" es:"reply_id"`
+	ReplyTitle       string `json:"reply_title,omitempty" es:"reply_title"`
+	ReplyDescription string `json:"reply_description,omitempty" es:"reply_description"`
+	ButtonPayload    string `json:"button_payload,omitempty" es:"button_payload"`
+
+	// Reaction (when MessageType == "reaction").
+	ReactionEmoji string `json:"reaction_emoji,omitempty" es:"reaction_emoji"`
+
 	ContextMessageID string `json:"context_message_id,omitempty" es:"context_message_id"`
 	IsForwarded      bool   `json:"is_forwarded,omitempty" es:"is_forwarded"`
 
@@ -75,13 +88,13 @@ type InboundConfig struct {
 
 // Conversation is an aggregated view grouping messages by contact.
 type Conversation struct {
-	ContactWAID    string    `json:"contact_wa_id"`
-	ContactName    string    `json:"contact_name"`
-	LastMessage    string    `json:"last_message"`
-	LastMessageAt  time.Time `json:"last_message_at"`
-	LastDirection  string    `json:"last_direction"`
-	UnreadCount    int64     `json:"unread_count"`
-	CSWOpen        bool      `json:"csw_open"`
+	ContactWAID   string    `json:"contact_wa_id"`
+	ContactName   string    `json:"contact_name"`
+	LastMessage   string    `json:"last_message"`
+	LastMessageAt time.Time `json:"last_message_at"`
+	LastDirection string    `json:"last_direction"`
+	UnreadCount   int64     `json:"unread_count"`
+	CSWOpen       bool      `json:"csw_open"`
 }
 
 // MessageFilter is used to query stored WhatsApp messages.

--- a/internal/domain/whatsapp/rich.go
+++ b/internal/domain/whatsapp/rich.go
@@ -1,0 +1,218 @@
+package whatsapp
+
+import (
+	"context"
+	"time"
+)
+
+// RichTemplateKind enumerates the rich-messaging template types supported by
+// FreeRangeNotify across Meta Cloud API and Twilio Content API. Each kind has
+// a matching renderer in the provider packages and a validation rule set in
+// validate.go. Adding a new kind requires: (a) extending the validator,
+// (b) wiring it in MetaWhatsAppProvider.buildRichMessage and the Twilio
+// provider, and (c) (when persisted) extending the rich-template
+// authoring service to translate the FRN-internal shape to the provider's
+// upstream submission JSON.
+type RichTemplateKind string
+
+const (
+	KindCarousel      RichTemplateKind = "carousel"
+	KindCouponCode    RichTemplateKind = "coupon_code"
+	KindCTAURL        RichTemplateKind = "cta_url"
+	KindQuickReply    RichTemplateKind = "quick_reply"
+	KindList          RichTemplateKind = "list"
+	KindSingleProduct RichTemplateKind = "single_product"
+	KindMultiProduct  RichTemplateKind = "multi_product"
+	KindCatalog       RichTemplateKind = "catalog"
+)
+
+// ButtonType enumerates the WhatsApp template button types we expose.
+// CALL is intentionally absent for now — Meta supports a PHONE_NUMBER button
+// but our authoring API only ships the four below in the first cut.
+type ButtonType string
+
+const (
+	ButtonQuickReply ButtonType = "QUICK_REPLY"
+	ButtonURL        ButtonType = "URL"
+	ButtonPhone      ButtonType = "PHONE_NUMBER"
+	ButtonCopyCode   ButtonType = "COPY_CODE"
+)
+
+// ApprovalState reflects the *aggregate* approval status across Meta and
+// Twilio. Per-provider statuses live in ProviderBindings; ApprovalState is
+// the rolled-up view the UI surfaces on the template list.
+type ApprovalState string
+
+const (
+	ApprovalDraft               ApprovalState = "draft"               // never submitted
+	ApprovalPending             ApprovalState = "pending"             // submitted, awaiting at least one provider
+	ApprovalPartiallySubmitted  ApprovalState = "partially_submitted" // submitted to one provider, the other failed
+	ApprovalApproved            ApprovalState = "approved"            // approved by at least one configured provider
+	ApprovalRejected            ApprovalState = "rejected"            // rejected by all configured providers
+	ApprovalDisabled            ApprovalState = "disabled"            // approved then disabled by provider (rare)
+)
+
+// RichTemplate is the FRN-internal representation of a rich WhatsApp
+// template. Persisted in Elasticsearch (index `whatsapp_rich_templates`) and
+// keyed by `(tenant_id, app_id, name)` enforced at the service layer (Meta
+// itself enforces uniqueness of name per WABA).
+//
+// The send-time payload (notification.Content.Data["whatsapp_rich"]) does
+// NOT use this struct directly — it carries `template_id` plus runtime
+// variables and the service resolves the binding. RichTemplate is the
+// authoring shape; the runtime shape is intentionally narrower.
+type RichTemplate struct {
+	ID        string `json:"id" es:"id"`             // FRN-internal ID (frn_tpl_*)
+	TenantID  string `json:"tenant_id" es:"tenant_id"`
+	AppID     string `json:"app_id" es:"app_id"`
+	Name      string `json:"name" es:"name"`         // snake_case, unique per app
+	Kind      RichTemplateKind `json:"kind" es:"kind"`
+	Language  string `json:"language" es:"language"` // BCP-47, e.g. en_US
+	Category  string `json:"category" es:"category"` // MARKETING | UTILITY | AUTHENTICATION
+
+	// Authoring payload (provider-agnostic). Optional per kind:
+	//   carousel:     Cards (required, 2..10)
+	//   coupon_code:  Body, CouponCode
+	//   cta_url:      Body, Buttons (1 URL button)
+	//   quick_reply:  Body, Buttons (1..3 QUICK_REPLY buttons)
+	//   list:         Body, ListSections, ListButtonText
+	Body            string           `json:"body,omitempty" es:"body"`
+	Header          *Header          `json:"header,omitempty" es:"header"`
+	Footer          string           `json:"footer,omitempty" es:"footer"`
+	Cards           []CarouselCard   `json:"cards,omitempty" es:"cards"`
+	Buttons         []Button         `json:"buttons,omitempty" es:"buttons"`
+	CouponCode      string           `json:"coupon_code,omitempty" es:"coupon_code"`
+	ListButtonText  string           `json:"list_button_text,omitempty" es:"list_button_text"`
+	ListSections    []ListSection    `json:"list_sections,omitempty" es:"list_sections"`
+
+	// Provider linkage (filled after submission).
+	Providers     ProviderBindings `json:"providers" es:"providers"`
+	ApprovalState ApprovalState    `json:"approval_state" es:"approval_state"`
+
+	CreatedAt time.Time `json:"created_at" es:"created_at"`
+	UpdatedAt time.Time `json:"updated_at" es:"updated_at"`
+}
+
+// Header is a template header. Exactly one of Text / ImageURL / VideoURL /
+// DocumentURL is set; the validator rejects multiples.
+type Header struct {
+	Text        string `json:"text,omitempty" es:"text"`
+	ImageURL    string `json:"image_url,omitempty" es:"image_url"`
+	VideoURL    string `json:"video_url,omitempty" es:"video_url"`
+	DocumentURL string `json:"document_url,omitempty" es:"document_url"`
+}
+
+// CarouselCard is one card in a carousel template. Cards must share the same
+// header media type across the carousel (enforced by the validator).
+type CarouselCard struct {
+	HeaderImageURL string   `json:"header_image_url,omitempty" es:"header_image_url"`
+	HeaderVideoURL string   `json:"header_video_url,omitempty" es:"header_video_url"`
+	Body           string   `json:"body" es:"body"`             // ≤160 chars
+	Variables      []string `json:"variables,omitempty" es:"variables"` // names matching {{1}}..{{n}}
+	Buttons        []Button `json:"buttons" es:"buttons"`       // 1..2 per card
+}
+
+// Button is a single template button. The relevant fields depend on Type:
+//   QUICK_REPLY: Text + Payload
+//   URL:         Text + URL (with optional {{1}} suffix variable + Example)
+//   PHONE_NUMBER: Text + PhoneNumber
+//   COPY_CODE:   Text + CouponCode
+//
+// TrackClicks=true wraps the URL in `/v1/r/{sig}` at send-time for click
+// attribution (Phase 3). Only meaningful for URL buttons.
+type Button struct {
+	Type        ButtonType `json:"type" es:"type"`
+	Text        string     `json:"text" es:"text"`
+	URL         string     `json:"url,omitempty" es:"url"`
+	Payload     string     `json:"payload,omitempty" es:"payload"`
+	PhoneNumber string     `json:"phone_number,omitempty" es:"phone_number"`
+	CouponCode  string     `json:"coupon_code,omitempty" es:"coupon_code"`
+	Example     string     `json:"example,omitempty" es:"example"` // required by Meta for URL with {{n}}
+	TrackClicks bool       `json:"track_clicks,omitempty" es:"track_clicks"`
+}
+
+// ListSection is one section in a list-picker template.
+type ListSection struct {
+	Title string    `json:"title" es:"title"`
+	Rows  []ListRow `json:"rows" es:"rows"` // 1..10 per section
+}
+
+// ListRow is one row inside a list section.
+type ListRow struct {
+	ID          string `json:"id" es:"id"`                     // returned as ReplyID on tap
+	Title       string `json:"title" es:"title"`               // ≤24 chars
+	Description string `json:"description,omitempty" es:"description"` // ≤72 chars
+}
+
+// ProviderBindings holds the per-provider IDs and approval status assigned
+// by Meta / Twilio after submission. Either binding may be nil if the app
+// is not configured for that provider.
+type ProviderBindings struct {
+	Meta   *MetaBinding   `json:"meta,omitempty" es:"meta"`
+	Twilio *TwilioBinding `json:"twilio,omitempty" es:"twilio"`
+}
+
+// MetaBinding is the Meta side of a submitted template.
+type MetaBinding struct {
+	TemplateName string    `json:"template_name" es:"template_name"`
+	TemplateID   string    `json:"template_id" es:"template_id"`
+	Status       string    `json:"status" es:"status"`             // APPROVED | PENDING | REJECTED | DISABLED
+	Reason       string    `json:"reason,omitempty" es:"reason"`
+	SubmittedAt  time.Time `json:"submitted_at,omitempty" es:"submitted_at"`
+	UpdatedAt    time.Time `json:"updated_at,omitempty" es:"updated_at"`
+}
+
+// TwilioBinding is the Twilio Content API side of a submitted template.
+type TwilioBinding struct {
+	ContentSid  string    `json:"content_sid" es:"content_sid"`
+	ApprovalSid string    `json:"approval_sid,omitempty" es:"approval_sid"`
+	Status      string    `json:"status" es:"status"`           // approved | pending | rejected | unsubmitted
+	Reason      string    `json:"reason,omitempty" es:"reason"`
+	SubmittedAt time.Time `json:"submitted_at,omitempty" es:"submitted_at"`
+	UpdatedAt   time.Time `json:"updated_at,omitempty" es:"updated_at"`
+}
+
+// SendPayload is the runtime shape carried in
+// notification.Content.Data["whatsapp_rich"] for typed rich sends. It is
+// resolved server-side against a RichTemplate to produce provider-specific
+// JSON.
+//
+// Fields are union-style: TemplateID is the FRN-internal ID; the worker
+// loads the template and maps Variables / Cards onto its components.
+type SendPayload struct {
+	TemplateID string                 `json:"template_id"`
+	Variables  map[string]string      `json:"variables,omitempty"`
+	Cards      []SendPayloadCard      `json:"cards,omitempty"`
+}
+
+// SendPayloadCard is per-card runtime overrides for a carousel send.
+type SendPayloadCard struct {
+	HeaderImageURL string            `json:"header_image_url,omitempty"`
+	HeaderVideoURL string            `json:"header_video_url,omitempty"`
+	Variables      map[string]string `json:"variables,omitempty"`
+	// ButtonValues fills the URL suffix or payload variable for each button
+	// in card order. nil means "no runtime substitution required".
+	ButtonValues []string `json:"button_values,omitempty"`
+}
+
+// RichTemplateFilter describes a query for listing rich templates.
+type RichTemplateFilter struct {
+	TenantID string `json:"tenant_id"`
+	AppID    string `json:"app_id"`
+	Kind     string `json:"kind,omitempty"`
+	Status   string `json:"status,omitempty"` // aggregate ApprovalState
+	NamePrefix string `json:"name_prefix,omitempty"`
+	Limit  int `json:"limit,omitempty"`
+	Offset int `json:"offset,omitempty"`
+}
+
+// RichTemplateRepository is the persistence interface for RichTemplate.
+// Implemented by infrastructure/repository/whatsapp_rich_template_repo.go.
+type RichTemplateRepository interface {
+	Create(ctx context.Context, tpl *RichTemplate) error
+	GetByID(ctx context.Context, id string) (*RichTemplate, error)
+	GetByName(ctx context.Context, appID, name string) (*RichTemplate, error)
+	List(ctx context.Context, filter RichTemplateFilter) ([]*RichTemplate, int64, error)
+	Update(ctx context.Context, tpl *RichTemplate) error
+	Delete(ctx context.Context, id string) error
+}

--- a/internal/domain/whatsapp/validate.go
+++ b/internal/domain/whatsapp/validate.go
@@ -1,0 +1,449 @@
+package whatsapp
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"unicode/utf8"
+)
+
+// Hard limits derived from Meta's WhatsApp template policy (April 2026) and
+// Twilio Content API constraints. Centralised here so we can swap in tighter
+// per-provider limits later without touching call sites.
+const (
+	maxCarouselCards     = 10
+	minCarouselCards     = 2
+	maxCardBodyChars     = 160
+	maxButtonsPerCard    = 2
+	minButtonsPerCard    = 1
+	maxQuickReplyButtons = 3
+	maxListSections      = 10
+	maxRowsPerSection    = 10
+	maxRowTitleChars     = 24
+	maxRowDescChars      = 72
+	maxTemplateNameChars = 512
+	maxBodyChars         = 1024
+	maxHeaderTextChars   = 60
+	maxFooterChars       = 60
+)
+
+// Lower-case-snake_case names only. Meta and Twilio both reject upper-case
+// or hyphenated template names at submission time; failing fast here keeps
+// the user out of a long round-trip.
+var templateNameRE = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
+
+// variableRE finds `{{1}}`, `{{2}}` … in a body string. Whitespace tolerant
+// to match human-typed templates.
+var variableRE = regexp.MustCompile(`\{\{\s*(\d+)\s*\}\}`)
+
+// ValidationError aggregates all problems found in a single Validate call so
+// the UI can surface them all at once instead of one-at-a-time.
+type ValidationError struct {
+	Field   string `json:"field"`
+	Message string `json:"message"`
+	Code    string `json:"code,omitempty"`
+}
+
+func (e ValidationError) Error() string {
+	if e.Field == "" {
+		return e.Message
+	}
+	return fmt.Sprintf("%s: %s", e.Field, e.Message)
+}
+
+// ValidationErrors is the multi-error wrapper Validate returns. Implements
+// the error interface and is JSON-marshalable as a flat list.
+type ValidationErrors []ValidationError
+
+func (es ValidationErrors) Error() string {
+	if len(es) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(es))
+	for _, e := range es {
+		parts = append(parts, e.Error())
+	}
+	return strings.Join(parts, "; ")
+}
+
+// IsEmpty reports whether there are no errors so callers can `if errs := Validate(t); errs.IsEmpty() {...}`.
+func (es ValidationErrors) IsEmpty() bool { return len(es) == 0 }
+
+// Validate runs all enforceable rules against a RichTemplate. The intent is
+// to mirror Meta + Twilio's submit-time rejection rules so callers get
+// immediate feedback rather than a delayed approval rejection.
+//
+// Validate is intentionally provider-agnostic; provider-specific downgrades
+// (e.g. Twilio's lack of video carousel headers) are handled separately at
+// submission time so the same template can target both providers.
+func Validate(t *RichTemplate) ValidationErrors {
+	var errs ValidationErrors
+
+	if t == nil {
+		return append(errs, ValidationError{Field: "template", Message: "template is nil"})
+	}
+
+	errs = append(errs, validateName(t.Name)...)
+	errs = append(errs, validateCommon(t)...)
+
+	switch t.Kind {
+	case KindCarousel:
+		errs = append(errs, validateCarousel(t)...)
+	case KindCouponCode:
+		errs = append(errs, validateCouponCode(t)...)
+	case KindCTAURL:
+		errs = append(errs, validateCTAURL(t)...)
+	case KindQuickReply:
+		errs = append(errs, validateQuickReply(t)...)
+	case KindList:
+		errs = append(errs, validateList(t)...)
+	case KindSingleProduct, KindMultiProduct, KindCatalog:
+		// Product/catalog kinds are Phase 4. They submit a minimal template
+		// referencing a catalog_id at send-time, not an authored RichTemplate.
+		errs = append(errs, ValidationError{
+			Field:   "kind",
+			Message: fmt.Sprintf("kind %q is not yet supported in the authoring API", t.Kind),
+			Code:    "UNSUPPORTED_KIND",
+		})
+	default:
+		errs = append(errs, ValidationError{
+			Field:   "kind",
+			Message: fmt.Sprintf("unknown kind %q", t.Kind),
+			Code:    "UNKNOWN_KIND",
+		})
+	}
+
+	return errs
+}
+
+func validateName(name string) ValidationErrors {
+	var errs ValidationErrors
+	switch {
+	case name == "":
+		errs = append(errs, ValidationError{Field: "name", Message: "name is required"})
+	case utf8.RuneCountInString(name) > maxTemplateNameChars:
+		errs = append(errs, ValidationError{Field: "name", Message: fmt.Sprintf("name exceeds %d chars", maxTemplateNameChars)})
+	case !templateNameRE.MatchString(name):
+		errs = append(errs, ValidationError{
+			Field:   "name",
+			Message: "name must match ^[a-z][a-z0-9_]*$ (lower snake_case)",
+			Code:    "INVALID_NAME",
+		})
+	}
+	return errs
+}
+
+func validateCommon(t *RichTemplate) ValidationErrors {
+	var errs ValidationErrors
+	if t.AppID == "" {
+		errs = append(errs, ValidationError{Field: "app_id", Message: "app_id is required"})
+	}
+	if t.Language == "" {
+		errs = append(errs, ValidationError{Field: "language", Message: "language is required (e.g. en_US)"})
+	}
+	switch t.Category {
+	case "MARKETING", "UTILITY", "AUTHENTICATION":
+	case "":
+		errs = append(errs, ValidationError{Field: "category", Message: "category is required"})
+	default:
+		errs = append(errs, ValidationError{Field: "category", Message: "category must be MARKETING, UTILITY or AUTHENTICATION"})
+	}
+	if t.Header != nil {
+		errs = append(errs, validateHeader(t.Header)...)
+	}
+	if utf8.RuneCountInString(t.Body) > maxBodyChars {
+		errs = append(errs, ValidationError{Field: "body", Message: fmt.Sprintf("body exceeds %d chars", maxBodyChars)})
+	}
+	if utf8.RuneCountInString(t.Footer) > maxFooterChars {
+		errs = append(errs, ValidationError{Field: "footer", Message: fmt.Sprintf("footer exceeds %d chars", maxFooterChars)})
+	}
+	// Body variables must be contiguous starting at 1.
+	if !variableIndicesContiguous(t.Body) {
+		errs = append(errs, ValidationError{
+			Field:   "body",
+			Message: "body variables {{n}} must start at 1 and be contiguous (no gaps)",
+			Code:    "VARIABLE_GAP",
+		})
+	}
+	return errs
+}
+
+func validateHeader(h *Header) ValidationErrors {
+	var errs ValidationErrors
+	set := 0
+	if h.Text != "" {
+		set++
+		if utf8.RuneCountInString(h.Text) > maxHeaderTextChars {
+			errs = append(errs, ValidationError{Field: "header.text", Message: fmt.Sprintf("header text exceeds %d chars", maxHeaderTextChars)})
+		}
+	}
+	if h.ImageURL != "" {
+		set++
+	}
+	if h.VideoURL != "" {
+		set++
+	}
+	if h.DocumentURL != "" {
+		set++
+	}
+	if set > 1 {
+		errs = append(errs, ValidationError{
+			Field:   "header",
+			Message: "exactly one of header.text / image_url / video_url / document_url may be set",
+			Code:    "HEADER_MULTIPLE_TYPES",
+		})
+	}
+	return errs
+}
+
+func validateCarousel(t *RichTemplate) ValidationErrors {
+	var errs ValidationErrors
+	n := len(t.Cards)
+	if n < minCarouselCards || n > maxCarouselCards {
+		errs = append(errs, ValidationError{
+			Field:   "cards",
+			Message: fmt.Sprintf("carousel requires %d..%d cards (got %d)", minCarouselCards, maxCarouselCards, n),
+			Code:    "CAROUSEL_CARD_COUNT",
+		})
+		// Don't run per-card rules on an empty/oversized carousel; the count
+		// rule is more actionable on its own.
+		if n == 0 {
+			return errs
+		}
+	}
+
+	// All cards must share the same header media type (image or video). Meta
+	// rejects mixed types at submission.
+	headerType := cardHeaderType(t.Cards[0])
+	if headerType == "" {
+		errs = append(errs, ValidationError{Field: "cards[0]", Message: "first card must have either header_image_url or header_video_url"})
+	}
+	// All cards must use the same button type set in the same positions.
+	wantButtonShape := cardButtonShape(t.Cards[0])
+
+	for i, card := range t.Cards {
+		field := fmt.Sprintf("cards[%d]", i)
+		if utf8.RuneCountInString(card.Body) > maxCardBodyChars {
+			errs = append(errs, ValidationError{Field: field + ".body", Message: fmt.Sprintf("card body exceeds %d chars", maxCardBodyChars)})
+		}
+		if !variableIndicesContiguous(card.Body) {
+			errs = append(errs, ValidationError{Field: field + ".body", Message: "card body variables must be contiguous starting at 1"})
+		}
+		if ht := cardHeaderType(card); ht != headerType {
+			errs = append(errs, ValidationError{
+				Field:   field,
+				Message: fmt.Sprintf("card header type %q differs from first card %q — all cards must use the same media type", ht, headerType),
+				Code:    "CAROUSEL_MIXED_HEADERS",
+			})
+		}
+		if bc := len(card.Buttons); bc < minButtonsPerCard || bc > maxButtonsPerCard {
+			errs = append(errs, ValidationError{
+				Field:   field + ".buttons",
+				Message: fmt.Sprintf("each card needs %d..%d buttons (got %d)", minButtonsPerCard, maxButtonsPerCard, bc),
+				Code:    "CAROUSEL_BUTTON_COUNT",
+			})
+		}
+		if shape := cardButtonShape(card); shape != wantButtonShape {
+			errs = append(errs, ValidationError{
+				Field:   field + ".buttons",
+				Message: "all cards must use the same button types in the same order",
+				Code:    "CAROUSEL_MIXED_BUTTONS",
+			})
+		}
+		for j, b := range card.Buttons {
+			errs = append(errs, validateButton(b, fmt.Sprintf("%s.buttons[%d]", field, j))...)
+		}
+	}
+	return errs
+}
+
+func validateCouponCode(t *RichTemplate) ValidationErrors {
+	var errs ValidationErrors
+	if t.Body == "" {
+		errs = append(errs, ValidationError{Field: "body", Message: "body is required for coupon_code"})
+	}
+	if t.CouponCode == "" {
+		errs = append(errs, ValidationError{Field: "coupon_code", Message: "coupon_code is required"})
+	}
+	return errs
+}
+
+func validateCTAURL(t *RichTemplate) ValidationErrors {
+	var errs ValidationErrors
+	if t.Body == "" {
+		errs = append(errs, ValidationError{Field: "body", Message: "body is required for cta_url"})
+	}
+	if len(t.Buttons) != 1 || t.Buttons[0].Type != ButtonURL {
+		errs = append(errs, ValidationError{
+			Field:   "buttons",
+			Message: "cta_url requires exactly one URL button",
+			Code:    "CTA_URL_SHAPE",
+		})
+		return errs
+	}
+	errs = append(errs, validateButton(t.Buttons[0], "buttons[0]")...)
+	return errs
+}
+
+func validateQuickReply(t *RichTemplate) ValidationErrors {
+	var errs ValidationErrors
+	if t.Body == "" {
+		errs = append(errs, ValidationError{Field: "body", Message: "body is required for quick_reply"})
+	}
+	if n := len(t.Buttons); n < 1 || n > maxQuickReplyButtons {
+		errs = append(errs, ValidationError{
+			Field:   "buttons",
+			Message: fmt.Sprintf("quick_reply requires 1..%d buttons (got %d)", maxQuickReplyButtons, n),
+			Code:    "QUICK_REPLY_COUNT",
+		})
+	}
+	for i, b := range t.Buttons {
+		if b.Type != ButtonQuickReply {
+			errs = append(errs, ValidationError{
+				Field:   fmt.Sprintf("buttons[%d].type", i),
+				Message: "quick_reply template buttons must all be QUICK_REPLY",
+			})
+		}
+		errs = append(errs, validateButton(b, fmt.Sprintf("buttons[%d]", i))...)
+	}
+	return errs
+}
+
+func validateList(t *RichTemplate) ValidationErrors {
+	var errs ValidationErrors
+	if t.ListButtonText == "" {
+		errs = append(errs, ValidationError{Field: "list_button_text", Message: "list_button_text is required (the launcher label)"})
+	}
+	if n := len(t.ListSections); n < 1 || n > maxListSections {
+		errs = append(errs, ValidationError{
+			Field:   "list_sections",
+			Message: fmt.Sprintf("list requires 1..%d sections (got %d)", maxListSections, n),
+		})
+	}
+	for i, sec := range t.ListSections {
+		field := fmt.Sprintf("list_sections[%d]", i)
+		if sec.Title == "" {
+			errs = append(errs, ValidationError{Field: field + ".title", Message: "section title is required"})
+		}
+		if n := len(sec.Rows); n < 1 || n > maxRowsPerSection {
+			errs = append(errs, ValidationError{
+				Field:   field + ".rows",
+				Message: fmt.Sprintf("each section needs 1..%d rows (got %d)", maxRowsPerSection, n),
+			})
+		}
+		for j, r := range sec.Rows {
+			rf := fmt.Sprintf("%s.rows[%d]", field, j)
+			if r.ID == "" {
+				errs = append(errs, ValidationError{Field: rf + ".id", Message: "row id is required"})
+			}
+			if r.Title == "" {
+				errs = append(errs, ValidationError{Field: rf + ".title", Message: "row title is required"})
+			}
+			if utf8.RuneCountInString(r.Title) > maxRowTitleChars {
+				errs = append(errs, ValidationError{Field: rf + ".title", Message: fmt.Sprintf("row title exceeds %d chars", maxRowTitleChars)})
+			}
+			if utf8.RuneCountInString(r.Description) > maxRowDescChars {
+				errs = append(errs, ValidationError{Field: rf + ".description", Message: fmt.Sprintf("row description exceeds %d chars", maxRowDescChars)})
+			}
+		}
+	}
+	return errs
+}
+
+// validateButton runs the per-button checks for any kind that holds a Button
+// slice. The field prefix is the path the caller wants in the error.
+func validateButton(b Button, field string) ValidationErrors {
+	var errs ValidationErrors
+	if b.Text == "" {
+		errs = append(errs, ValidationError{Field: field + ".text", Message: "button text is required"})
+	}
+	switch b.Type {
+	case ButtonURL:
+		if b.URL == "" {
+			errs = append(errs, ValidationError{Field: field + ".url", Message: "URL is required for URL button"})
+		}
+		if hasVariable(b.URL) && b.Example == "" {
+			errs = append(errs, ValidationError{
+				Field:   field + ".example",
+				Message: "URL buttons with {{n}} variables require an example value (Meta submission requirement)",
+				Code:    "URL_BUTTON_EXAMPLE_MISSING",
+			})
+		}
+	case ButtonQuickReply:
+		if b.Payload == "" {
+			errs = append(errs, ValidationError{Field: field + ".payload", Message: "payload is required for QUICK_REPLY button"})
+		}
+	case ButtonPhone:
+		if b.PhoneNumber == "" {
+			errs = append(errs, ValidationError{Field: field + ".phone_number", Message: "phone_number is required for PHONE_NUMBER button"})
+		}
+	case ButtonCopyCode:
+		if b.CouponCode == "" {
+			errs = append(errs, ValidationError{Field: field + ".coupon_code", Message: "coupon_code is required for COPY_CODE button"})
+		}
+	case "":
+		errs = append(errs, ValidationError{Field: field + ".type", Message: "button type is required"})
+	default:
+		errs = append(errs, ValidationError{Field: field + ".type", Message: fmt.Sprintf("unknown button type %q", b.Type)})
+	}
+	return errs
+}
+
+// cardHeaderType returns "image", "video", or "" depending on which header
+// URL is set on a carousel card. Used to enforce uniform-header rule.
+func cardHeaderType(c CarouselCard) string {
+	switch {
+	case c.HeaderImageURL != "":
+		return "image"
+	case c.HeaderVideoURL != "":
+		return "video"
+	}
+	return ""
+}
+
+// cardButtonShape returns a stable string fingerprint of a card's button
+// types in order. Used to enforce "all cards use the same button types in
+// the same order" without false positives when the labels/URLs differ.
+func cardButtonShape(c CarouselCard) string {
+	parts := make([]string, len(c.Buttons))
+	for i, b := range c.Buttons {
+		parts[i] = string(b.Type)
+	}
+	return strings.Join(parts, "|")
+}
+
+// variableIndicesContiguous reports whether the {{n}} placeholders in s
+// form a contiguous sequence starting at 1. "Hello {{2}}" without {{1}} is
+// rejected by Meta at submission.
+func variableIndicesContiguous(s string) bool {
+	matches := variableRE.FindAllStringSubmatch(s, -1)
+	if len(matches) == 0 {
+		return true
+	}
+	seen := make(map[int]struct{}, len(matches))
+	max := 0
+	for _, m := range matches {
+		n := 0
+		// Manual atoi to avoid pulling strconv just for one parse — but
+		// strconv is fine. Using fmt.Sscanf would be silly. Just use strconv.
+		_, _ = fmt.Sscanf(m[1], "%d", &n)
+		if n < 1 {
+			return false
+		}
+		seen[n] = struct{}{}
+		if n > max {
+			max = n
+		}
+	}
+	for i := 1; i <= max; i++ {
+		if _, ok := seen[i]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// hasVariable reports whether s contains at least one {{n}} placeholder.
+func hasVariable(s string) bool {
+	return variableRE.MatchString(s)
+}

--- a/internal/domain/whatsapp/validate_test.go
+++ b/internal/domain/whatsapp/validate_test.go
@@ -1,0 +1,154 @@
+package whatsapp
+
+import (
+	"strings"
+	"testing"
+)
+
+// validCarousel is a minimum-viable carousel template used as the baseline
+// for the negative-case tests. Each test mutates one field then asserts that
+// Validate returns the expected error code, isolating the rule under test.
+func validCarousel() *RichTemplate {
+	return &RichTemplate{
+		Name:     "snapdeal_styles",
+		AppID:    "app-1",
+		Language: "en_US",
+		Category: "MARKETING",
+		Kind:     KindCarousel,
+		Body:     "Hi {{1}}, check these out:",
+		Cards: []CarouselCard{
+			{
+				HeaderImageURL: "https://cdn/.../1.jpg",
+				Body:           "Polo {{1}} {{2}}",
+				Buttons:        []Button{{Type: ButtonURL, Text: "View", URL: "https://shop/p/1"}},
+			},
+			{
+				HeaderImageURL: "https://cdn/.../2.jpg",
+				Body:           "Tee {{1}}",
+				Buttons:        []Button{{Type: ButtonURL, Text: "View", URL: "https://shop/p/2"}},
+			},
+		},
+	}
+}
+
+// TestValidate_HappyPaths covers one fully-populated example per kind.
+// Together they prove the validator does not reject well-formed templates.
+func TestValidate_HappyPaths(t *testing.T) {
+	cases := map[string]*RichTemplate{
+		"carousel":     validCarousel(),
+		"coupon_code":  {Name: "festive", AppID: "a", Language: "en_US", Category: "MARKETING", Kind: KindCouponCode, Body: "Use code", CouponCode: "DEAL50"},
+		"cta_url":      {Name: "see_more", AppID: "a", Language: "en_US", Category: "MARKETING", Kind: KindCTAURL, Body: "Tap below", Buttons: []Button{{Type: ButtonURL, Text: "Visit", URL: "https://x"}}},
+		"quick_reply":  {Name: "yes_no", AppID: "a", Language: "en_US", Category: "UTILITY", Kind: KindQuickReply, Body: "Confirm?", Buttons: []Button{{Type: ButtonQuickReply, Text: "Yes", Payload: "YES"}, {Type: ButtonQuickReply, Text: "No", Payload: "NO"}}},
+		"list":         {Name: "menu", AppID: "a", Language: "en_US", Category: "UTILITY", Kind: KindList, Body: "Pick one", ListButtonText: "Menu", ListSections: []ListSection{{Title: "Sizes", Rows: []ListRow{{ID: "s", Title: "S"}, {ID: "m", Title: "M"}}}}},
+	}
+	for name, tpl := range cases {
+		errs := Validate(tpl)
+		if !errs.IsEmpty() {
+			t.Errorf("%s: expected no errors, got %v", name, errs)
+		}
+	}
+}
+
+// TestValidate_NameRules exercises the snake_case + non-empty rules. Keeping
+// these in one table-driven test so the surface is obvious in one place.
+func TestValidate_NameRules(t *testing.T) {
+	cases := []struct {
+		name    string
+		wantErr string
+	}{
+		{"", "name is required"},
+		{"CamelCase", "lower snake_case"},
+		{"with-hyphen", "lower snake_case"},
+		{"1leading_digit", "lower snake_case"},
+		{strings.Repeat("a", maxTemplateNameChars+1), "exceeds"},
+	}
+	for _, tc := range cases {
+		tpl := validCarousel()
+		tpl.Name = tc.name
+		errs := Validate(tpl)
+		if errs.IsEmpty() || !strings.Contains(errs.Error(), tc.wantErr) {
+			t.Errorf("name %q: expected error containing %q, got %v", tc.name, tc.wantErr, errs)
+		}
+	}
+}
+
+// TestValidate_Carousel_MixedHeaders catches the most common Meta-submission
+// rejection: image header on card 0, video header on card 1.
+func TestValidate_Carousel_MixedHeaders(t *testing.T) {
+	tpl := validCarousel()
+	tpl.Cards[1].HeaderImageURL = ""
+	tpl.Cards[1].HeaderVideoURL = "https://cdn/.../v2.mp4"
+
+	errs := Validate(tpl)
+	if !containsCode(errs, "CAROUSEL_MIXED_HEADERS") {
+		t.Errorf("expected CAROUSEL_MIXED_HEADERS, got %v", errs)
+	}
+}
+
+// TestValidate_Carousel_MixedButtonTypes catches the second most common
+// submission rejection: card 0 is URL, card 1 is QUICK_REPLY.
+func TestValidate_Carousel_MixedButtonTypes(t *testing.T) {
+	tpl := validCarousel()
+	tpl.Cards[1].Buttons = []Button{{Type: ButtonQuickReply, Text: "Yes", Payload: "YES"}}
+
+	errs := Validate(tpl)
+	if !containsCode(errs, "CAROUSEL_MIXED_BUTTONS") {
+		t.Errorf("expected CAROUSEL_MIXED_BUTTONS, got %v", errs)
+	}
+}
+
+// TestValidate_Carousel_CountBoundaries covers the 2..10 card limit.
+func TestValidate_Carousel_CountBoundaries(t *testing.T) {
+	tpl := validCarousel()
+	tpl.Cards = tpl.Cards[:1] // 1 card
+
+	errs := Validate(tpl)
+	if !containsCode(errs, "CAROUSEL_CARD_COUNT") {
+		t.Errorf("expected CAROUSEL_CARD_COUNT for 1 card, got %v", errs)
+	}
+
+	tpl = validCarousel()
+	for len(tpl.Cards) < 11 {
+		tpl.Cards = append(tpl.Cards, tpl.Cards[0])
+	}
+	errs = Validate(tpl)
+	if !containsCode(errs, "CAROUSEL_CARD_COUNT") {
+		t.Errorf("expected CAROUSEL_CARD_COUNT for 11 cards, got %v", errs)
+	}
+}
+
+// TestValidate_Variables_Contiguous ensures we reject "Hello {{2}}" without {{1}}.
+func TestValidate_Variables_Contiguous(t *testing.T) {
+	tpl := validCarousel()
+	tpl.Body = "Hello {{2}}" // gap: missing {{1}}
+
+	errs := Validate(tpl)
+	if !containsCode(errs, "VARIABLE_GAP") {
+		t.Errorf("expected VARIABLE_GAP, got %v", errs)
+	}
+}
+
+// TestValidate_URLButton_ExampleRequired enforces Meta's submission rule
+// that URL buttons with variables must supply an example value.
+func TestValidate_URLButton_ExampleRequired(t *testing.T) {
+	tpl := &RichTemplate{
+		Name: "promo", AppID: "a", Language: "en_US", Category: "MARKETING",
+		Kind: KindCTAURL, Body: "See more",
+		Buttons: []Button{{Type: ButtonURL, Text: "Visit", URL: "https://shop/p/{{1}}"}}, // no Example
+	}
+	errs := Validate(tpl)
+	if !containsCode(errs, "URL_BUTTON_EXAMPLE_MISSING") {
+		t.Errorf("expected URL_BUTTON_EXAMPLE_MISSING, got %v", errs)
+	}
+}
+
+// containsCode is a tiny helper to assert that ValidationErrors carry at
+// least one error with the given Code, keeping the table tests terse.
+func containsCode(es ValidationErrors, code string) bool {
+	for _, e := range es {
+		if e.Code == code {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/infrastructure/database/index_manager.go
+++ b/internal/infrastructure/database/index_manager.go
@@ -80,6 +80,8 @@ func (im *IndexManager) CreateIndices(ctx context.Context) ([]IndexOperation, er
 
 		// WhatsApp Meta Tech Provider — inbound messages
 		"whatsapp_messages": im.templates.GetWhatsAppMessagesTemplate,
+		// Rich (carousel / coupon / cta / list) authoring store
+		"whatsapp_rich_templates": im.templates.GetWhatsAppRichTemplatesTemplate,
 	}
 
 	for indexName, templateFunc := range indices {

--- a/internal/infrastructure/database/index_templates.go
+++ b/internal/infrastructure/database/index_templates.go
@@ -1178,11 +1178,138 @@ func (it *IndexTemplates) GetWhatsAppMessagesTemplate() map[string]interface{} {
 				"longitude":          map[string]interface{}{"type": "float"},
 				"context_message_id": map[string]interface{}{"type": "keyword"},
 				"is_forwarded":       map[string]interface{}{"type": "boolean"},
+				// Interactive replies / template button taps surfaced as typed
+				// fields by the inbound webhook handler (instead of buried in
+				// raw_payload). Enables faceting + workflow triggers on
+				// reply_id, button_payload, etc.
+				"interactive_type":   map[string]interface{}{"type": "keyword"},
+				"reply_id":           map[string]interface{}{"type": "keyword"},
+				"reply_title":        map[string]interface{}{"type": "text"},
+				"reply_description":  map[string]interface{}{"type": "text"},
+				"button_payload":     map[string]interface{}{"type": "keyword"},
+				"reaction_emoji":     map[string]interface{}{"type": "keyword"},
 				"raw_payload": map[string]interface{}{
 					"type":    "object",
 					"enabled": false,
 				},
 				"created_at": map[string]interface{}{"type": "date"},
+			},
+		},
+	}
+}
+
+// GetWhatsAppRichTemplatesTemplate returns the Elasticsearch mapping for the
+// whatsapp_rich_templates index. This is the authored, provider-agnostic
+// rich-template store; per-provider IDs and approval status live nested
+// under `providers.{meta,twilio}`.
+//
+// Carousel cards, list sections, and buttons are stored as nested objects so
+// they can be queried independently (e.g. "list templates whose first card
+// has body text containing X") and to avoid the array-as-flat-document
+// pitfalls Elasticsearch's default object mapping has.
+func (it *IndexTemplates) GetWhatsAppRichTemplatesTemplate() map[string]interface{} {
+	return map[string]interface{}{
+		"settings": map[string]interface{}{
+			"number_of_shards":   1,
+			"number_of_replicas": 0,
+		},
+		"mappings": map[string]interface{}{
+			"properties": map[string]interface{}{
+				"id":             map[string]interface{}{"type": "keyword"},
+				"tenant_id":      map[string]interface{}{"type": "keyword"},
+				"app_id":         map[string]interface{}{"type": "keyword"},
+				"name":           map[string]interface{}{"type": "keyword"},
+				"kind":           map[string]interface{}{"type": "keyword"},
+				"language":       map[string]interface{}{"type": "keyword"},
+				"category":       map[string]interface{}{"type": "keyword"},
+				"body":           map[string]interface{}{"type": "text"},
+				"footer":         map[string]interface{}{"type": "text"},
+				"coupon_code":    map[string]interface{}{"type": "keyword"},
+				"approval_state": map[string]interface{}{"type": "keyword"},
+				"created_at":     map[string]interface{}{"type": "date"},
+				"updated_at":     map[string]interface{}{"type": "date"},
+				"header": map[string]interface{}{
+					"properties": map[string]interface{}{
+						"text":         map[string]interface{}{"type": "text"},
+						"image_url":    map[string]interface{}{"type": "keyword"},
+						"video_url":    map[string]interface{}{"type": "keyword"},
+						"document_url": map[string]interface{}{"type": "keyword"},
+					},
+				},
+				"cards": map[string]interface{}{
+					"type": "nested",
+					"properties": map[string]interface{}{
+						"header_image_url": map[string]interface{}{"type": "keyword"},
+						"header_video_url": map[string]interface{}{"type": "keyword"},
+						"body":             map[string]interface{}{"type": "text"},
+						"variables":        map[string]interface{}{"type": "keyword"},
+						"buttons": map[string]interface{}{
+							"type": "nested",
+							"properties": map[string]interface{}{
+								"type":         map[string]interface{}{"type": "keyword"},
+								"text":         map[string]interface{}{"type": "text"},
+								"url":          map[string]interface{}{"type": "keyword"},
+								"payload":      map[string]interface{}{"type": "keyword"},
+								"phone_number": map[string]interface{}{"type": "keyword"},
+								"coupon_code":  map[string]interface{}{"type": "keyword"},
+								"example":      map[string]interface{}{"type": "text"},
+								"track_clicks": map[string]interface{}{"type": "boolean"},
+							},
+						},
+					},
+				},
+				"buttons": map[string]interface{}{
+					"type": "nested",
+					"properties": map[string]interface{}{
+						"type":         map[string]interface{}{"type": "keyword"},
+						"text":         map[string]interface{}{"type": "text"},
+						"url":          map[string]interface{}{"type": "keyword"},
+						"payload":      map[string]interface{}{"type": "keyword"},
+						"phone_number": map[string]interface{}{"type": "keyword"},
+						"coupon_code":  map[string]interface{}{"type": "keyword"},
+						"example":      map[string]interface{}{"type": "text"},
+						"track_clicks": map[string]interface{}{"type": "boolean"},
+					},
+				},
+				"list_button_text": map[string]interface{}{"type": "keyword"},
+				"list_sections": map[string]interface{}{
+					"type": "nested",
+					"properties": map[string]interface{}{
+						"title": map[string]interface{}{"type": "text"},
+						"rows": map[string]interface{}{
+							"type": "nested",
+							"properties": map[string]interface{}{
+								"id":          map[string]interface{}{"type": "keyword"},
+								"title":       map[string]interface{}{"type": "text"},
+								"description": map[string]interface{}{"type": "text"},
+							},
+						},
+					},
+				},
+				"providers": map[string]interface{}{
+					"properties": map[string]interface{}{
+						"meta": map[string]interface{}{
+							"properties": map[string]interface{}{
+								"template_name": map[string]interface{}{"type": "keyword"},
+								"template_id":   map[string]interface{}{"type": "keyword"},
+								"status":        map[string]interface{}{"type": "keyword"},
+								"reason":        map[string]interface{}{"type": "text"},
+								"submitted_at":  map[string]interface{}{"type": "date"},
+								"updated_at":    map[string]interface{}{"type": "date"},
+							},
+						},
+						"twilio": map[string]interface{}{
+							"properties": map[string]interface{}{
+								"content_sid":  map[string]interface{}{"type": "keyword"},
+								"approval_sid": map[string]interface{}{"type": "keyword"},
+								"status":       map[string]interface{}{"type": "keyword"},
+								"reason":       map[string]interface{}{"type": "text"},
+								"submitted_at": map[string]interface{}{"type": "date"},
+								"updated_at":   map[string]interface{}{"type": "date"},
+							},
+						},
+					},
+				},
 			},
 		},
 	}

--- a/internal/infrastructure/providers/meta_whatsapp_provider.go
+++ b/internal/infrastructure/providers/meta_whatsapp_provider.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/the-monkeys/freerangenotify/internal/domain/application"
@@ -85,14 +86,46 @@ type metaLanguage struct {
 }
 
 type metaComponent struct {
-	Type       string          `json:"type"`
+	Type    string `json:"type"`               // "header" | "body" | "footer" | "button" | "carousel"
+	SubType string `json:"sub_type,omitempty"` // "URL" | "QUICK_REPLY" | "COPY_CODE" (only for button)
+	// Meta sends Index as a string in the JSON ("0", "1"...) — that is the
+	// position of the button inside the template definition.
+	Index      string          `json:"index,omitempty"`
 	Parameters []metaParameter `json:"parameters,omitempty"`
+
+	// Carousel-only: each carousel component holds an array of cards.
+	Cards []metaCard `json:"cards,omitempty"`
+}
+
+// metaCard is a single carousel card. The Meta Cloud API expects an explicit
+// card_index (0-based) plus a nested components array mirroring the standard
+// header/body/button structure.
+type metaCard struct {
+	CardIndex  int             `json:"card_index"`
+	Components []metaComponent `json:"components"`
 }
 
 type metaParameter struct {
-	Type  string `json:"type"`
-	Text  string `json:"text,omitempty"`
-	Image *metaMedia `json:"image,omitempty"`
+	Type       string             `json:"type"`
+	Text       string             `json:"text,omitempty"`
+	Payload    string             `json:"payload,omitempty"`     // QUICK_REPLY button payload
+	CouponCode string             `json:"coupon_code,omitempty"` // COPY_CODE button code
+	Image      *metaMedia         `json:"image,omitempty"`
+	Video      *metaMedia         `json:"video,omitempty"`
+	Document   *metaDocumentMedia `json:"document,omitempty"`
+	Location   *metaLocation      `json:"location,omitempty"`
+	Currency   *metaCurrency      `json:"currency,omitempty"`
+	DateTime   *metaDateTime      `json:"date_time,omitempty"`
+}
+
+type metaCurrency struct {
+	FallbackValue string `json:"fallback_value"`
+	Code          string `json:"code"`
+	Amount1000    int64  `json:"amount_1000"`
+}
+
+type metaDateTime struct {
+	FallbackValue string `json:"fallback_value"`
 }
 
 type metaMedia struct {
@@ -167,11 +200,78 @@ type metaInteractiveFooter struct {
 }
 
 type metaInteractiveAction struct {
-	Buttons  []metaButton  `json:"buttons,omitempty"`
-	Button   string        `json:"button,omitempty"`
-	Sections []metaSection `json:"sections,omitempty"`
-	Name     string        `json:"name,omitempty"`
-	Parameters *metaCTAParams `json:"parameters,omitempty"`
+	Buttons    []metaButton   `json:"buttons,omitempty"`
+	Button     string         `json:"button,omitempty"`
+	Sections   []metaSection  `json:"sections,omitempty"`
+	Name       string         `json:"name,omitempty"`
+	Parameters *metaCTAParams `json:"-"` // see MarshalJSON
+	// Catalog / commerce fields (Phase 4 of WHATSAPP_RICH_INTERACTIVE_PLAN.md).
+	// Single-product (interactive.type=product) populates CatalogID +
+	// ProductRetailerID. Multi-product (interactive.type=product_list)
+	// populates CatalogID + ProductSections instead of Sections (text rows).
+	// CatalogMessage uses CatalogParameters with thumbnail_product_retailer_id.
+	CatalogID         string               `json:"catalog_id,omitempty"`
+	ProductRetailerID string               `json:"product_retailer_id,omitempty"`
+	ProductSections   []metaProductSection `json:"-"`
+	CatalogParameters *metaCatalogParams   `json:"-"`
+}
+
+// MarshalJSON for metaInteractiveAction encodes the polymorphic action
+// shape Meta requires. Three discriminated cases share one type to keep
+// the rest of the codebase free of action-variant unions:
+//
+//   * cta_url            → emits `parameters: {display_text, url}`
+//   * catalog_message    → emits `parameters: {thumbnail_product_retailer_id}`
+//   * product_list       → emits `sections: [{title, product_items[]}, ...]`
+//
+// `sections` is mutually exclusive between text-list and product-list;
+// per Meta only one of them ships on the wire.
+func (a metaInteractiveAction) MarshalJSON() ([]byte, error) {
+	type alias metaInteractiveAction
+	out := struct {
+		alias
+		Sections   interface{} `json:"sections,omitempty"`
+		Parameters interface{} `json:"parameters,omitempty"`
+	}{alias: alias(a)}
+
+	switch {
+	case len(a.ProductSections) > 0:
+		out.Sections = a.ProductSections
+	case len(a.Sections) > 0:
+		out.Sections = a.Sections
+	}
+	switch {
+	case a.CatalogParameters != nil:
+		out.Parameters = a.CatalogParameters
+	case a.Parameters != nil:
+		out.Parameters = a.Parameters
+	}
+
+	// Clear the embedded copies so they don't double-emit (alias retains
+	// the un-tagged shape; we route them through the explicit fields).
+	out.alias.Sections = nil
+	out.alias.ProductSections = nil
+	out.alias.Parameters = nil
+	out.alias.CatalogParameters = nil
+	return json.Marshal(out)
+}
+
+// metaProductSection is one section inside a product_list interactive
+// message. Each product_item references a catalog SKU by retailer ID.
+type metaProductSection struct {
+	Title        string            `json:"title,omitempty"`
+	ProductItems []metaProductItem `json:"product_items"`
+}
+
+type metaProductItem struct {
+	ProductRetailerID string `json:"product_retailer_id"`
+}
+
+// metaCatalogParams is the `action.parameters` payload for
+// interactive.type=catalog_message. The optional thumbnail picks a hero
+// product for the catalog launcher card.
+type metaCatalogParams struct {
+	ThumbnailProductRetailerID string `json:"thumbnail_product_retailer_id,omitempty"`
 }
 
 type metaButton struct {
@@ -325,6 +425,18 @@ func (p *MetaWhatsAppProvider) Send(ctx context.Context, notif *notification.Not
 // buildMessage constructs the Meta API message payload.
 func (p *MetaWhatsAppProvider) buildMessage(notif *notification.Notification, toNumber string) metaMessage {
 	if notif.Content.Data != nil {
+		// Rich typed payloads (carousel / coupon / etc.) take precedence over
+		// the lower-level whatsapp_template path so callers can opt into the
+		// validated, kind-aware DSL without losing back-compat for raw
+		// templates already in use.
+		if richData, ok := notif.Content.Data["whatsapp_rich"]; ok {
+			if rich, ok := richData.(map[string]interface{}); ok {
+				if msg, ok := p.buildRichMessage(rich, toNumber); ok {
+					return msg
+				}
+			}
+		}
+
 		// WhatsApp template
 		if tplData, ok := notif.Content.Data["whatsapp_template"]; ok {
 			if tpl, ok := tplData.(map[string]interface{}); ok {
@@ -587,6 +699,12 @@ func (p *MetaWhatsAppProvider) buildContactsMessage(contacts []interface{}, toNu
 }
 
 // buildTemplateMessage constructs a template message from content data.
+//
+// Supports the full Meta parameter taxonomy required by approved templates:
+// text, image/video/document/location headers, currency, date_time, and
+// BUTTON components with sub_type (URL / QUICK_REPLY / COPY_CODE) + index.
+// Dropping any of these silently is the most common cause of "template
+// rendered blank header" or "URL button missing" on the recipient device.
 func (p *MetaWhatsAppProvider) buildTemplateMessage(tpl map[string]interface{}, toNumber string) metaMessage {
 	name, _ := tpl["name"].(string)
 	lang, _ := tpl["language"].(string)
@@ -605,32 +723,110 @@ func (p *MetaWhatsAppProvider) buildTemplateMessage(tpl map[string]interface{}, 
 		},
 	}
 
-	// Parse components if present
-	if comps, ok := tpl["components"].([]interface{}); ok {
-		for _, c := range comps {
-			comp, ok := c.(map[string]interface{})
-			if !ok {
-				continue
-			}
-			mc := metaComponent{Type: fmt.Sprintf("%v", comp["type"])}
-			if params, ok := comp["parameters"].([]interface{}); ok {
-				for _, param := range params {
-					pm, ok := param.(map[string]interface{})
-					if !ok {
-						continue
-					}
-					mp := metaParameter{Type: fmt.Sprintf("%v", pm["type"])}
-					if text, ok := pm["text"].(string); ok {
-						mp.Text = text
-					}
-					mc.Parameters = append(mc.Parameters, mp)
-				}
-			}
-			msg.Template.Components = append(msg.Template.Components, mc)
+	comps, ok := tpl["components"].([]interface{})
+	if !ok {
+		return msg
+	}
+	for _, c := range comps {
+		comp, ok := c.(map[string]interface{})
+		if !ok {
+			continue
 		}
+		mc := metaComponent{Type: stringField(comp, "type")}
+		if v := stringField(comp, "sub_type"); v != "" {
+			mc.SubType = v
+		}
+		// Index arrives either as JSON string ("0") or number (0) depending
+		// on the caller — normalise to string per Meta's spec.
+		if idx, ok := comp["index"]; ok {
+			mc.Index = fmt.Sprintf("%v", idx)
+		}
+		if params, ok := comp["parameters"].([]interface{}); ok {
+			for _, param := range params {
+				pm, ok := param.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				mc.Parameters = append(mc.Parameters, parseTemplateParam(pm))
+			}
+		}
+		msg.Template.Components = append(msg.Template.Components, mc)
 	}
 
 	return msg
+}
+
+// parseTemplateParam converts a single Meta template parameter from the
+// untyped map[string]interface{} input shape to a typed metaParameter.
+// Unknown parameter types pass through with Text populated when present so
+// the worker never silently drops data that may still be valid for newer
+// Meta features.
+func parseTemplateParam(pm map[string]interface{}) metaParameter {
+	mp := metaParameter{Type: stringField(pm, "type")}
+	switch mp.Type {
+	case "text":
+		mp.Text = stringField(pm, "text")
+	case "payload":
+		mp.Payload = stringField(pm, "payload")
+	case "coupon_code":
+		mp.CouponCode = stringField(pm, "coupon_code")
+	case "image":
+		if media, ok := pm["image"].(map[string]interface{}); ok {
+			mp.Image = &metaMedia{Link: stringField(media, "link"), ID: stringField(media, "id"), Caption: stringField(media, "caption")}
+		}
+	case "video":
+		if media, ok := pm["video"].(map[string]interface{}); ok {
+			mp.Video = &metaMedia{Link: stringField(media, "link"), ID: stringField(media, "id"), Caption: stringField(media, "caption")}
+		}
+	case "document":
+		if media, ok := pm["document"].(map[string]interface{}); ok {
+			mp.Document = &metaDocumentMedia{
+				Link:     stringField(media, "link"),
+				ID:       stringField(media, "id"),
+				Caption:  stringField(media, "caption"),
+				Filename: stringField(media, "filename"),
+			}
+		}
+	case "location":
+		if loc, ok := pm["location"].(map[string]interface{}); ok {
+			lat, _ := loc["latitude"].(float64)
+			lng, _ := loc["longitude"].(float64)
+			mp.Location = &metaLocation{
+				Latitude:  lat,
+				Longitude: lng,
+				Name:      stringField(loc, "name"),
+				Address:   stringField(loc, "address"),
+			}
+		}
+	case "currency":
+		if cur, ok := pm["currency"].(map[string]interface{}); ok {
+			amount, _ := cur["amount_1000"].(float64)
+			mp.Currency = &metaCurrency{
+				FallbackValue: stringField(cur, "fallback_value"),
+				Code:          stringField(cur, "code"),
+				Amount1000:    int64(amount),
+			}
+		}
+	case "date_time":
+		if dt, ok := pm["date_time"].(map[string]interface{}); ok {
+			mp.DateTime = &metaDateTime{FallbackValue: stringField(dt, "fallback_value")}
+		}
+	default:
+		// Forward-compatible: keep `text` if a caller used a new parameter
+		// type Meta added since this code was written.
+		mp.Text = stringField(pm, "text")
+	}
+	return mp
+}
+
+// stringField is a small helper that returns the string value at key, or ""
+// if the key is missing or the value is not a string. Avoids the repetitive
+// `v, _ := m[k].(string)` pattern in parsing code.
+func stringField(m map[string]interface{}, key string) string {
+	if v, ok := m[key].(string); ok {
+		return v
+	}
+	return ""
 }
 
 // handleErrorResponse parses a Meta API error and returns an appropriate Result.
@@ -706,6 +902,367 @@ func (p *MetaWhatsAppProvider) IsHealthy(_ context.Context) bool { return true }
 
 // Close releases provider resources.
 func (p *MetaWhatsAppProvider) Close() error { return nil }
+
+// buildRichMessage routes the typed whatsapp_rich payload to the appropriate
+// renderer based on its "kind". Returns (msg, true) on a recognized,
+// well-formed kind; (zero, false) when the payload is malformed or the kind
+// is unknown so the caller can fall through to legacy renderers.
+//
+// Caller-friendly shape accepted today:
+//
+//	{
+//	  "kind": "carousel" | "coupon_code",
+//	  "template_name": "trendy_styles_carousel",
+//	  "language": "en_US",
+//	  "body_variables": ["Asha"],          // BODY {{1}}, {{2}}, ...
+//	  "cards": [                            // carousel only
+//	    {
+//	      "header_image_url": "https://cdn/.../1.jpg",
+//	      "header_video_url": "https://...",   // alt to image
+//	      "body_variables":   ["Polo", "₹229"],
+//	      "buttons": [
+//	        { "sub_type": "URL",         "text": "p/12345" },
+//	        { "sub_type": "QUICK_REPLY", "payload": "REORDER_42" }
+//	      ]
+//	    }
+//	  ],
+//	  "coupon_code": "DEAL50"              // coupon_code only
+//	}
+func (p *MetaWhatsAppProvider) buildRichMessage(rich map[string]interface{}, toNumber string) (metaMessage, bool) {
+	kind := stringField(rich, "kind")
+
+	// Product / multi-product / catalog kinds are NOT templates — they
+	// build interactive messages and don't require a template_name.
+	switch kind {
+	case "product":
+		return p.buildProductMessage(rich, toNumber)
+	case "multi_product":
+		return p.buildMultiProductMessage(rich, toNumber)
+	case "catalog":
+		return p.buildCatalogMessage(rich, toNumber)
+	}
+
+	templateName := stringField(rich, "template_name")
+	if templateName == "" {
+		return metaMessage{}, false
+	}
+	language := stringField(rich, "language")
+	if language == "" {
+		language = "en_US"
+	}
+
+	msg := metaMessage{
+		MessagingProduct: "whatsapp",
+		RecipientType:    "individual",
+		To:               toNumber,
+		Type:             "template",
+		Template: &metaTemplate{
+			Name:     templateName,
+			Language: metaLanguage{Code: language},
+		},
+	}
+
+	// Top-level BODY parameters apply to all kinds: they fill {{1}}..{{n}} in
+	// the template body outside the cards array.
+	if body := buildBodyComponent(rich["body_variables"]); body != nil {
+		msg.Template.Components = append(msg.Template.Components, *body)
+	}
+
+	switch kind {
+	case "carousel":
+		cards, ok := buildCarouselCards(rich["cards"])
+		if !ok {
+			return metaMessage{}, false
+		}
+		msg.Template.Components = append(msg.Template.Components, metaComponent{
+			Type:  "carousel",
+			Cards: cards,
+		})
+		return msg, true
+
+	case "coupon_code":
+		code := stringField(rich, "coupon_code")
+		if code == "" {
+			return metaMessage{}, false
+		}
+		msg.Template.Components = append(msg.Template.Components, metaComponent{
+			Type:    "button",
+			SubType: "COPY_CODE",
+			Index:   "0",
+			Parameters: []metaParameter{
+				{Type: "coupon_code", CouponCode: code},
+			},
+		})
+		return msg, true
+
+	default:
+		// Unknown kind — caller can fall through to legacy whatsapp_template.
+		return metaMessage{}, false
+	}
+}
+
+// buildBodyComponent turns a []interface{} of strings into a BODY component
+// of typed text parameters. Returns nil when the input is missing or empty
+// so callers can omit the component entirely (Meta rejects empty components).
+func buildBodyComponent(raw interface{}) *metaComponent {
+	vars, ok := raw.([]interface{})
+	if !ok || len(vars) == 0 {
+		return nil
+	}
+	params := make([]metaParameter, 0, len(vars))
+	for _, v := range vars {
+		params = append(params, metaParameter{Type: "text", Text: fmt.Sprintf("%v", v)})
+	}
+	return &metaComponent{Type: "body", Parameters: params}
+}
+
+// buildCarouselCards converts the caller's "cards" array into Meta's
+// card_index + components shape. Returns (cards, false) when the array is
+// missing or empty so the caller can refuse to send a malformed carousel.
+func buildCarouselCards(raw interface{}) ([]metaCard, bool) {
+	arr, ok := raw.([]interface{})
+	if !ok || len(arr) == 0 {
+		return nil, false
+	}
+	cards := make([]metaCard, 0, len(arr))
+	for i, c := range arr {
+		cm, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		card := metaCard{CardIndex: i}
+
+		if header := buildCardHeader(cm); header != nil {
+			card.Components = append(card.Components, *header)
+		}
+		if body := buildBodyComponent(cm["body_variables"]); body != nil {
+			card.Components = append(card.Components, *body)
+		}
+		for btnIdx, b := range cardButtons(cm["buttons"]) {
+			b.Index = fmt.Sprintf("%d", btnIdx)
+			card.Components = append(card.Components, b)
+		}
+		cards = append(cards, card)
+	}
+	if len(cards) == 0 {
+		return nil, false
+	}
+	return cards, true
+}
+
+// buildCardHeader picks the first present header media (image > video >
+// document) for a card. Carousel cards must have uniform header type across
+// all cards per Meta's spec; that is enforced at authoring time, not here.
+func buildCardHeader(cm map[string]interface{}) *metaComponent {
+	if link := stringField(cm, "header_image_url"); link != "" {
+		return &metaComponent{Type: "header", Parameters: []metaParameter{{Type: "image", Image: &metaMedia{Link: link}}}}
+	}
+	if link := stringField(cm, "header_video_url"); link != "" {
+		return &metaComponent{Type: "header", Parameters: []metaParameter{{Type: "video", Video: &metaMedia{Link: link}}}}
+	}
+	if doc, ok := cm["header_document"].(map[string]interface{}); ok {
+		return &metaComponent{Type: "header", Parameters: []metaParameter{{Type: "document", Document: &metaDocumentMedia{
+			Link:     stringField(doc, "link"),
+			Filename: stringField(doc, "filename"),
+		}}}}
+	}
+	return nil
+}
+
+// cardButtons normalises the per-card buttons array into typed button
+// components. Each button needs sub_type (URL | QUICK_REPLY | COPY_CODE) and
+// the appropriate parameter. The card-relative index is assigned by the
+// caller — see buildCarouselCards.
+func cardButtons(raw interface{}) []metaComponent {
+	arr, ok := raw.([]interface{})
+	if !ok {
+		return nil
+	}
+	out := make([]metaComponent, 0, len(arr))
+	for _, b := range arr {
+		bm, ok := b.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		subType := strings.ToUpper(stringField(bm, "sub_type"))
+		if subType == "" {
+			continue
+		}
+		comp := metaComponent{Type: "button", SubType: subType}
+		switch subType {
+		case "URL":
+			if text := stringField(bm, "text"); text != "" {
+				comp.Parameters = []metaParameter{{Type: "text", Text: text}}
+			}
+		case "QUICK_REPLY":
+			if payload := stringField(bm, "payload"); payload != "" {
+				comp.Parameters = []metaParameter{{Type: "payload", Payload: payload}}
+			}
+		case "COPY_CODE":
+			if code := stringField(bm, "coupon_code"); code != "" {
+				comp.Parameters = []metaParameter{{Type: "coupon_code", CouponCode: code}}
+			}
+		default:
+			// Unknown sub_type — skip rather than emit malformed JSON.
+			continue
+		}
+		out = append(out, comp)
+	}
+	return out
+}
+
+// buildProductMessage emits an interactive.type=product payload (Meta
+// commerce single-product card). Expected `rich` shape:
+//
+//	{
+//	  "kind": "product",
+//	  "body": "Check out our hero product",
+//	  "footer": "Tap to view",
+//	  "catalog_id": "1234567890",
+//	  "product_retailer_id": "sku-001"
+//	}
+func (p *MetaWhatsAppProvider) buildProductMessage(rich map[string]interface{}, toNumber string) (metaMessage, bool) {
+	catalogID := stringField(rich, "catalog_id")
+	productID := stringField(rich, "product_retailer_id")
+	if catalogID == "" || productID == "" {
+		return metaMessage{}, false
+	}
+	body := stringField(rich, "body")
+	msg := metaMessage{
+		MessagingProduct: "whatsapp",
+		RecipientType:    "individual",
+		To:               toNumber,
+		Type:             "interactive",
+		Interactive: &metaInteractive{
+			Type: "product",
+			Body: metaInteractiveBody{Text: body},
+			Action: metaInteractiveAction{
+				CatalogID:         catalogID,
+				ProductRetailerID: productID,
+			},
+		},
+	}
+	if footer := stringField(rich, "footer"); footer != "" {
+		msg.Interactive.Footer = &metaInteractiveFooter{Text: footer}
+	}
+	return msg, true
+}
+
+// buildMultiProductMessage emits an interactive.type=product_list payload
+// (Meta commerce multi-product picker). Expected `rich` shape:
+//
+//	{
+//	  "kind": "multi_product",
+//	  "header": "Best Sellers",
+//	  "body":   "Pick your favourite",
+//	  "footer": "Free shipping today",
+//	  "catalog_id": "1234567890",
+//	  "sections": [
+//	    {
+//	      "title": "Tops",
+//	      "product_retailer_ids": ["sku-1", "sku-2"]
+//	    },
+//	    ...
+//	  ]
+//	}
+func (p *MetaWhatsAppProvider) buildMultiProductMessage(rich map[string]interface{}, toNumber string) (metaMessage, bool) {
+	catalogID := stringField(rich, "catalog_id")
+	if catalogID == "" {
+		return metaMessage{}, false
+	}
+	sectionsRaw, _ := rich["sections"].([]interface{})
+	if len(sectionsRaw) == 0 {
+		return metaMessage{}, false
+	}
+
+	sections := make([]metaProductSection, 0, len(sectionsRaw))
+	for _, s := range sectionsRaw {
+		sm, ok := s.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		idsRaw, _ := sm["product_retailer_ids"].([]interface{})
+		items := make([]metaProductItem, 0, len(idsRaw))
+		for _, id := range idsRaw {
+			if str, ok := id.(string); ok && str != "" {
+				items = append(items, metaProductItem{ProductRetailerID: str})
+			}
+		}
+		if len(items) == 0 {
+			continue
+		}
+		sections = append(sections, metaProductSection{
+			Title:        stringField(sm, "title"),
+			ProductItems: items,
+		})
+	}
+	if len(sections) == 0 {
+		return metaMessage{}, false
+	}
+
+	msg := metaMessage{
+		MessagingProduct: "whatsapp",
+		RecipientType:    "individual",
+		To:               toNumber,
+		Type:             "interactive",
+		Interactive: &metaInteractive{
+			Type: "product_list",
+			Body: metaInteractiveBody{Text: stringField(rich, "body")},
+			Action: metaInteractiveAction{
+				CatalogID:       catalogID,
+				ProductSections: sections,
+			},
+		},
+	}
+	if header := stringField(rich, "header"); header != "" {
+		msg.Interactive.Header = &metaInteractiveHeader{Type: "text", Text: header}
+	}
+	if footer := stringField(rich, "footer"); footer != "" {
+		msg.Interactive.Footer = &metaInteractiveFooter{Text: footer}
+	}
+	return msg, true
+}
+
+// buildCatalogMessage emits an interactive.type=catalog_message payload
+// (full catalog browser launch). Expected `rich` shape:
+//
+//	{
+//	  "kind": "catalog",
+//	  "body": "Browse our catalog",
+//	  "footer": "Tap below",
+//	  "thumbnail_product_retailer_id": "sku-hero"
+//	}
+//
+// catalog_message uses the app's bound catalog automatically — there is
+// no catalog_id field on the wire (Meta resolves it from the WABA's
+// commerce settings).
+func (p *MetaWhatsAppProvider) buildCatalogMessage(rich map[string]interface{}, toNumber string) (metaMessage, bool) {
+	body := stringField(rich, "body")
+	if body == "" {
+		return metaMessage{}, false
+	}
+	thumb := stringField(rich, "thumbnail_product_retailer_id")
+	msg := metaMessage{
+		MessagingProduct: "whatsapp",
+		RecipientType:    "individual",
+		To:               toNumber,
+		Type:             "interactive",
+		Interactive: &metaInteractive{
+			Type: "catalog_message",
+			Body: metaInteractiveBody{Text: body},
+			Action: metaInteractiveAction{
+				Name: "catalog_message",
+			},
+		},
+	}
+	if thumb != "" {
+		msg.Interactive.Action.CatalogParameters = &metaCatalogParams{ThumbnailProductRetailerID: thumb}
+	}
+	if footer := stringField(rich, "footer"); footer != "" {
+		msg.Interactive.Footer = &metaInteractiveFooter{Text: footer}
+	}
+	return msg, true
+}
 
 func init() {
 	RegisterFactory("meta_whatsapp", func(cfg map[string]interface{}, logger *zap.Logger) (Provider, error) {

--- a/internal/infrastructure/providers/meta_whatsapp_provider_test.go
+++ b/internal/infrastructure/providers/meta_whatsapp_provider_test.go
@@ -1,0 +1,469 @@
+package providers
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/the-monkeys/freerangenotify/internal/domain/notification"
+	"go.uber.org/zap"
+)
+
+// newTestMetaProvider constructs a MetaWhatsAppProvider with a no-op logger
+// for unit tests that exercise build* helpers in isolation.
+func newTestMetaProvider(t *testing.T) *MetaWhatsAppProvider {
+	t.Helper()
+	p, err := NewMetaWhatsAppProvider(MetaWhatsAppConfig{
+		PhoneNumberID: "stub",
+		AccessToken:   "stub",
+	}, zap.NewNop())
+	if err != nil {
+		t.Fatalf("provider init: %v", err)
+	}
+	return p
+}
+
+// TestBuildTemplateMessage_AllParameterTypes verifies that every Meta
+// template parameter type round-trips through the build path. Regression
+// guard: prior to this change, only `text` parameters were forwarded, which
+// caused approved templates with media headers or URL buttons to render
+// blank on the device. The test asserts a) the typed structs are populated
+// correctly, and b) the JSON Meta sees over the wire matches the spec.
+func TestBuildTemplateMessage_AllParameterTypes(t *testing.T) {
+	p := newTestMetaProvider(t)
+	tpl := map[string]interface{}{
+		"name":     "order_shipped",
+		"language": "en_US",
+		"components": []interface{}{
+			map[string]interface{}{
+				"type": "header",
+				"parameters": []interface{}{
+					map[string]interface{}{
+						"type":  "image",
+						"image": map[string]interface{}{"link": "https://cdn.example/h.jpg"},
+					},
+				},
+			},
+			map[string]interface{}{
+				"type": "body",
+				"parameters": []interface{}{
+					map[string]interface{}{"type": "text", "text": "Asha"},
+					map[string]interface{}{
+						"type": "currency",
+						"currency": map[string]interface{}{
+							"fallback_value": "$12.34",
+							"code":           "USD",
+							"amount_1000":    float64(12340),
+						},
+					},
+					map[string]interface{}{
+						"type":      "date_time",
+						"date_time": map[string]interface{}{"fallback_value": "Jan 1, 2026"},
+					},
+				},
+			},
+			map[string]interface{}{
+				"type":     "button",
+				"sub_type": "URL",
+				"index":    "0",
+				"parameters": []interface{}{
+					map[string]interface{}{"type": "text", "text": "track/ORD-42"},
+				},
+			},
+			map[string]interface{}{
+				"type":     "button",
+				"sub_type": "QUICK_REPLY",
+				"index":    float64(1), // also accept JSON number form
+				"parameters": []interface{}{
+					map[string]interface{}{"type": "payload", "payload": "REORDER_42"},
+				},
+			},
+		},
+	}
+
+	msg := p.buildTemplateMessage(tpl, "15551234567")
+
+	if msg.Type != "template" || msg.Template == nil {
+		t.Fatalf("expected template message, got %+v", msg)
+	}
+	if msg.Template.Name != "order_shipped" {
+		t.Errorf("template name: got %q, want order_shipped", msg.Template.Name)
+	}
+	if got, want := len(msg.Template.Components), 4; got != want {
+		t.Fatalf("components: got %d, want %d", got, want)
+	}
+
+	header := msg.Template.Components[0]
+	if header.Type != "header" || len(header.Parameters) != 1 {
+		t.Fatalf("header component shape: %+v", header)
+	}
+	if header.Parameters[0].Image == nil || header.Parameters[0].Image.Link != "https://cdn.example/h.jpg" {
+		t.Errorf("image param dropped: %+v", header.Parameters[0])
+	}
+
+	body := msg.Template.Components[1]
+	if len(body.Parameters) != 3 {
+		t.Fatalf("body params: got %d, want 3", len(body.Parameters))
+	}
+	if body.Parameters[1].Currency == nil || body.Parameters[1].Currency.Code != "USD" || body.Parameters[1].Currency.Amount1000 != 12340 {
+		t.Errorf("currency param dropped: %+v", body.Parameters[1])
+	}
+	if body.Parameters[2].DateTime == nil || body.Parameters[2].DateTime.FallbackValue != "Jan 1, 2026" {
+		t.Errorf("date_time param dropped: %+v", body.Parameters[2])
+	}
+
+	urlBtn := msg.Template.Components[2]
+	if urlBtn.SubType != "URL" || urlBtn.Index != "0" {
+		t.Errorf("URL button missing sub_type/index: %+v", urlBtn)
+	}
+
+	qrBtn := msg.Template.Components[3]
+	if qrBtn.SubType != "QUICK_REPLY" || qrBtn.Index != "1" {
+		t.Errorf("QUICK_REPLY button missing sub_type/index: %+v", qrBtn)
+	}
+	if qrBtn.Parameters[0].Type != "payload" || qrBtn.Parameters[0].Payload != "REORDER_42" {
+		t.Errorf("QUICK_REPLY payload dropped: %+v", qrBtn.Parameters[0])
+	}
+
+	// Wire-shape: the JSON Meta receives must include sub_type, index, and
+	// the parameter sub-objects. Spot-check fields that broke before.
+	raw, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	wire := string(raw)
+	for _, needle := range []string{
+		`"sub_type":"URL"`,
+		`"sub_type":"QUICK_REPLY"`,
+		`"index":"0"`,
+		`"index":"1"`,
+		`"payload":"REORDER_42"`,
+		`"amount_1000":12340`,
+		`"fallback_value":"Jan 1, 2026"`,
+		`"link":"https://cdn.example/h.jpg"`,
+	} {
+		if !contains(wire, needle) {
+			t.Errorf("expected JSON to contain %q\nwire: %s", needle, wire)
+		}
+	}
+}
+
+// TestBuildRichMessage_Carousel renders a two-card Snapdeal-style carousel
+// via the typed whatsapp_rich payload and asserts that the wire JSON Meta
+// receives matches the Cloud API carousel template spec: a top-level BODY
+// component plus a `carousel` component whose cards each carry an image
+// HEADER, a BODY with positional text parameters, and a card-scoped URL
+// button with sub_type/index/parameters set correctly.
+func TestBuildRichMessage_Carousel(t *testing.T) {
+	p := newTestMetaProvider(t)
+	rich := map[string]interface{}{
+		"kind":           "carousel",
+		"template_name":  "trendy_styles_carousel",
+		"language":       "en_US",
+		"body_variables": []interface{}{"Asha"},
+		"cards": []interface{}{
+			map[string]interface{}{
+				"header_image_url": "https://cdn.example/p1.jpg",
+				"body_variables":   []interface{}{"Trendy Polo", "₹229.00"},
+				"buttons": []interface{}{
+					map[string]interface{}{"sub_type": "URL", "text": "p/12345"},
+				},
+			},
+			map[string]interface{}{
+				"header_image_url": "https://cdn.example/p2.jpg",
+				"body_variables":   []interface{}{"Athleisure Polo", "₹260.00"},
+				"buttons": []interface{}{
+					map[string]interface{}{"sub_type": "URL", "text": "p/67890"},
+					map[string]interface{}{"sub_type": "QUICK_REPLY", "payload": "SHOP_NOW"},
+				},
+			},
+		},
+	}
+
+	notif := &notification.Notification{
+		NotificationID: "n-2",
+		Content:        notification.Content{Data: map[string]interface{}{"whatsapp_rich": rich}},
+	}
+
+	msg := p.buildMessage(notif, "15551234567")
+	if msg.Type != "template" || msg.Template == nil {
+		t.Fatalf("expected template, got %+v", msg)
+	}
+	if msg.Template.Name != "trendy_styles_carousel" {
+		t.Errorf("template name: got %q", msg.Template.Name)
+	}
+	if got, want := len(msg.Template.Components), 2; got != want {
+		t.Fatalf("top-level components: got %d, want %d (body + carousel)", got, want)
+	}
+	if msg.Template.Components[0].Type != "body" {
+		t.Errorf("first component should be body, got %s", msg.Template.Components[0].Type)
+	}
+
+	car := msg.Template.Components[1]
+	if car.Type != "carousel" || len(car.Cards) != 2 {
+		t.Fatalf("carousel shape wrong: %+v", car)
+	}
+
+	if car.Cards[0].CardIndex != 0 || car.Cards[1].CardIndex != 1 {
+		t.Errorf("card_index not 0/1: %d, %d", car.Cards[0].CardIndex, car.Cards[1].CardIndex)
+	}
+
+	// Card 1 has two buttons → button indexes must be card-scoped 0 and 1
+	c1 := car.Cards[1]
+	var btnIdxs []string
+	for _, comp := range c1.Components {
+		if comp.Type == "button" {
+			btnIdxs = append(btnIdxs, comp.Index)
+		}
+	}
+	if len(btnIdxs) != 2 || btnIdxs[0] != "0" || btnIdxs[1] != "1" {
+		t.Errorf("card-scoped button indexes wrong: %v", btnIdxs)
+	}
+
+	// Wire-shape spot-checks against Meta's documented carousel JSON.
+	raw, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	wire := string(raw)
+	for _, needle := range []string{
+		`"type":"carousel"`,
+		`"card_index":0`,
+		`"card_index":1`,
+		`"link":"https://cdn.example/p1.jpg"`,
+		`"link":"https://cdn.example/p2.jpg"`,
+		`"sub_type":"URL"`,
+		`"sub_type":"QUICK_REPLY"`,
+		`"payload":"SHOP_NOW"`,
+	} {
+		if !contains(wire, needle) {
+			t.Errorf("expected JSON to contain %q\nwire: %s", needle, wire)
+		}
+	}
+}
+
+// TestBuildRichMessage_CouponCode renders a template with a COPY_CODE button
+// (the WhatsApp coupon-share pattern). Verifies the button parameter uses
+// type=coupon_code with the literal code, which is what Meta expects to
+// surface the "Copy" CTA on the recipient device.
+func TestBuildRichMessage_CouponCode(t *testing.T) {
+	p := newTestMetaProvider(t)
+	rich := map[string]interface{}{
+		"kind":           "coupon_code",
+		"template_name":  "festive_discount",
+		"language":       "en_US",
+		"body_variables": []interface{}{"Diwali", "50"},
+		"coupon_code":    "DEAL50",
+	}
+	notif := &notification.Notification{
+		Content: notification.Content{Data: map[string]interface{}{"whatsapp_rich": rich}},
+	}
+	msg := p.buildMessage(notif, "15551234567")
+	if msg.Type != "template" {
+		t.Fatalf("expected template, got %s", msg.Type)
+	}
+	wire := mustJSON(t, msg)
+	for _, needle := range []string{
+		`"sub_type":"COPY_CODE"`,
+		`"index":"0"`,
+		`"type":"coupon_code"`,
+		`"coupon_code":"DEAL50"`,
+		`"text":"Diwali"`,
+	} {
+		if !contains(wire, needle) {
+			t.Errorf("expected JSON to contain %q\nwire: %s", needle, wire)
+		}
+	}
+}
+
+// TestBuildRichMessage_FallsThroughOnMalformed asserts that a malformed
+// whatsapp_rich blob (missing template_name, no cards for a carousel, unknown
+// kind) does NOT crash and does NOT short-circuit the renderer — the caller
+// gets the plain-text fallback so something still ships.
+func TestBuildRichMessage_FallsThroughOnMalformed(t *testing.T) {
+	p := newTestMetaProvider(t)
+	cases := []map[string]interface{}{
+		{"kind": "carousel"},                            // no template_name
+		{"kind": "carousel", "template_name": "x"},      // no cards
+		{"kind": "unknown_kind", "template_name": "x"},  // unknown kind
+		{"kind": "coupon_code", "template_name": "x"},   // no coupon_code
+	}
+	for i, rich := range cases {
+		notif := &notification.Notification{
+			Content: notification.Content{
+				Body: "fallback body",
+				Data: map[string]interface{}{"whatsapp_rich": rich},
+			},
+		}
+		msg := p.buildMessage(notif, "15551234567")
+		if msg.Type != "text" {
+			t.Errorf("case %d: expected text fallback, got %s (rich=%+v)", i, msg.Type, rich)
+		}
+	}
+}
+
+func mustJSON(t *testing.T, v interface{}) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(b)
+}
+
+// TestBuildMessage_DefaultsToText guards against regressions where adding a
+// new whatsapp_* data key inadvertently breaks the fall-through to a plain
+// text message.
+func TestBuildMessage_DefaultsToText(t *testing.T) {
+	p := newTestMetaProvider(t)
+	notif := &notification.Notification{
+		NotificationID: "n-1",
+		Content: notification.Content{
+			Title: "Hello",
+			Body:  "world",
+		},
+	}
+	msg := p.buildMessage(notif, "15551234567")
+	if msg.Type != "text" || msg.Text == nil {
+		t.Fatalf("expected text fallback, got %+v", msg)
+	}
+	if msg.Text.Body == "" {
+		t.Errorf("text body empty")
+	}
+}
+
+// TestBuildRichMessage_SingleProduct asserts a kind=product payload renders
+// as interactive.type=product with catalog_id + product_retailer_id on the
+// action root, not under template components. Validates the Phase 4
+// commerce path.
+func TestBuildRichMessage_SingleProduct(t *testing.T) {
+	p := newTestMetaProvider(t)
+	notif := &notification.Notification{
+		Content: notification.Content{
+			Data: map[string]interface{}{
+				"whatsapp_rich": map[string]interface{}{
+					"kind":                "product",
+					"body":                "Check it out",
+					"footer":              "Tap to view",
+					"catalog_id":          "1234567890",
+					"product_retailer_id": "sku-001",
+				},
+			},
+		},
+	}
+	msg := p.buildMessage(notif, "15551234567")
+	if msg.Type != "interactive" || msg.Interactive == nil {
+		t.Fatalf("expected interactive message, got %s / %+v", msg.Type, msg.Interactive)
+	}
+	if msg.Interactive.Type != "product" {
+		t.Errorf("interactive.type: got %q want product", msg.Interactive.Type)
+	}
+	wire := mustJSON(t, msg)
+	for _, needle := range []string{
+		`"type":"product"`,
+		`"catalog_id":"1234567890"`,
+		`"product_retailer_id":"sku-001"`,
+		`"body":{"text":"Check it out"}`,
+		`"footer":{"text":"Tap to view"}`,
+	} {
+		if !contains(wire, needle) {
+			t.Errorf("missing %q in wire JSON\nwire: %s", needle, wire)
+		}
+	}
+}
+
+// TestBuildRichMessage_MultiProduct asserts a kind=multi_product payload
+// renders as interactive.type=product_list with the section.product_items
+// shape Meta requires. The MarshalJSON override is exercised here.
+func TestBuildRichMessage_MultiProduct(t *testing.T) {
+	p := newTestMetaProvider(t)
+	notif := &notification.Notification{
+		Content: notification.Content{
+			Data: map[string]interface{}{
+				"whatsapp_rich": map[string]interface{}{
+					"kind":       "multi_product",
+					"header":     "Best Sellers",
+					"body":       "Pick one",
+					"footer":     "Free shipping today",
+					"catalog_id": "999",
+					"sections": []interface{}{
+						map[string]interface{}{
+							"title":                "Tops",
+							"product_retailer_ids": []interface{}{"sku-1", "sku-2"},
+						},
+						map[string]interface{}{
+							"title":                "Bottoms",
+							"product_retailer_ids": []interface{}{"sku-3"},
+						},
+					},
+				},
+			},
+		},
+	}
+	msg := p.buildMessage(notif, "15551234567")
+	if msg.Type != "interactive" || msg.Interactive == nil || msg.Interactive.Type != "product_list" {
+		t.Fatalf("expected interactive.product_list, got %+v", msg.Interactive)
+	}
+	wire := mustJSON(t, msg)
+	for _, needle := range []string{
+		`"type":"product_list"`,
+		`"catalog_id":"999"`,
+		`"sections":[`,
+		`"title":"Tops"`,
+		`"product_items":[{"product_retailer_id":"sku-1"},{"product_retailer_id":"sku-2"}]`,
+		`"header":{"type":"text","text":"Best Sellers"}`,
+		`"footer":{"text":"Free shipping today"}`,
+	} {
+		if !contains(wire, needle) {
+			t.Errorf("missing %q in wire JSON\nwire: %s", needle, wire)
+		}
+	}
+}
+
+// TestBuildRichMessage_Catalog asserts a kind=catalog payload renders as
+// interactive.type=catalog_message with the thumbnail key emitted under
+// action.parameters — the bespoke field Meta requires for the catalog
+// launcher's hero product.
+func TestBuildRichMessage_Catalog(t *testing.T) {
+	p := newTestMetaProvider(t)
+	notif := &notification.Notification{
+		Content: notification.Content{
+			Data: map[string]interface{}{
+				"whatsapp_rich": map[string]interface{}{
+					"kind":                          "catalog",
+					"body":                          "Browse our catalog",
+					"footer":                        "Tap below",
+					"thumbnail_product_retailer_id": "sku-hero",
+				},
+			},
+		},
+	}
+	msg := p.buildMessage(notif, "15551234567")
+	if msg.Type != "interactive" || msg.Interactive == nil || msg.Interactive.Type != "catalog_message" {
+		t.Fatalf("expected interactive.catalog_message, got %+v", msg.Interactive)
+	}
+	wire := mustJSON(t, msg)
+	for _, needle := range []string{
+		`"type":"catalog_message"`,
+		`"name":"catalog_message"`,
+		`"parameters":{"thumbnail_product_retailer_id":"sku-hero"}`,
+		`"body":{"text":"Browse our catalog"}`,
+	} {
+		if !contains(wire, needle) {
+			t.Errorf("missing %q in wire JSON\nwire: %s", needle, wire)
+		}
+	}
+}
+
+// contains is a tiny helper to keep the table-driven assertions above terse.
+func contains(haystack, needle string) bool {
+	return len(haystack) >= len(needle) && indexOf(haystack, needle) >= 0
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/infrastructure/repository/analytics_event_repo.go
+++ b/internal/infrastructure/repository/analytics_event_repo.go
@@ -1,0 +1,37 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/elastic/go-elasticsearch/v8"
+	"github.com/the-monkeys/freerangenotify/internal/domain/analytics"
+	"go.uber.org/zap"
+)
+
+// AnalyticsEventRepository persists analytics events to the `analytics`
+// Elasticsearch index. This is a minimal implementation focused on the
+// Track() path used by the click-attribution redirect handler — full
+// analytics.Repository (summaries, channel stats, …) lives in a separate
+// later milestone.
+type AnalyticsEventRepository struct {
+	base *BaseRepository
+}
+
+// NewAnalyticsEventRepository wires up the repo. Uses RefreshFalse since
+// analytics writes are bursty and downstream dashboards tolerate ~1s
+// indexing latency.
+func NewAnalyticsEventRepository(client *elasticsearch.Client, logger *zap.Logger) *AnalyticsEventRepository {
+	return &AnalyticsEventRepository{
+		base: NewBaseRepository(client, "analytics", logger, RefreshFalse),
+	}
+}
+
+// Track persists a single Event keyed by Event.ID.
+func (r *AnalyticsEventRepository) Track(ctx context.Context, e *analytics.Event) error {
+	if e.ID == "" {
+		// Fall back to a generated suffix; we don't want duplicate-key
+		// failures from clients that didn't bother to set ID.
+		e.ID = e.NotificationID + "_" + string(e.EventType)
+	}
+	return r.base.Create(ctx, e.ID, e)
+}

--- a/internal/infrastructure/repository/whatsapp_rich_template_repo.go
+++ b/internal/infrastructure/repository/whatsapp_rich_template_repo.go
@@ -1,0 +1,166 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/elastic/go-elasticsearch/v8"
+	"github.com/the-monkeys/freerangenotify/internal/domain/whatsapp"
+	"go.uber.org/zap"
+)
+
+// WhatsAppRichTemplateRepository persists RichTemplate documents in the
+// `whatsapp_rich_templates` Elasticsearch index. Uses RefreshWaitFor so
+// authoring round-trips (POST /v1/whatsapp/rich-templates → GET) see the
+// fresh document immediately — at the cost of slightly slower writes, which
+// is acceptable for an authoring API rather than a send-hot-path.
+type WhatsAppRichTemplateRepository struct {
+	base   *BaseRepository
+	logger *zap.Logger
+}
+
+// NewWhatsAppRichTemplateRepository wires up a repository backed by the
+// given Elasticsearch client. Implements whatsapp.RichTemplateRepository.
+func NewWhatsAppRichTemplateRepository(client *elasticsearch.Client, logger *zap.Logger) whatsapp.RichTemplateRepository {
+	return &WhatsAppRichTemplateRepository{
+		base:   NewBaseRepository(client, "whatsapp_rich_templates", logger, RefreshWaitFor),
+		logger: logger,
+	}
+}
+
+// Create persists a new RichTemplate. Caller is responsible for assigning
+// the FRN-internal ID (frn_tpl_*) and stamping CreatedAt / UpdatedAt — this
+// stays consistent with the rest of the repository layer which avoids
+// hidden time mutations so test fixtures stay deterministic.
+func (r *WhatsAppRichTemplateRepository) Create(ctx context.Context, tpl *whatsapp.RichTemplate) error {
+	if tpl == nil || tpl.ID == "" {
+		return fmt.Errorf("rich template missing id")
+	}
+	return r.base.Create(ctx, tpl.ID, tpl)
+}
+
+// GetByID fetches a template by FRN-internal ID. Returns the standard
+// pkgerrors.NotFound when the document is missing, propagated from
+// BaseRepository.GetByID.
+func (r *WhatsAppRichTemplateRepository) GetByID(ctx context.Context, id string) (*whatsapp.RichTemplate, error) {
+	doc, err := r.base.GetByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	var tpl whatsapp.RichTemplate
+	if err := mapToStruct(doc, &tpl); err != nil {
+		return nil, fmt.Errorf("failed to map rich template document: %w", err)
+	}
+	return &tpl, nil
+}
+
+// GetByName fetches a template by (app_id, name). Returns nil + nil when the
+// document is missing so callers can use this to enforce idempotent create
+// without distinguishing a real ES error from a not-found result.
+func (r *WhatsAppRichTemplateRepository) GetByName(ctx context.Context, appID, name string) (*whatsapp.RichTemplate, error) {
+	query := map[string]interface{}{
+		"size": 1,
+		"query": map[string]interface{}{
+			"bool": map[string]interface{}{
+				"must": []map[string]interface{}{
+					{"term": map[string]interface{}{"app_id": appID}},
+					{"term": map[string]interface{}{"name": name}},
+				},
+			},
+		},
+	}
+	result, err := r.base.Search(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	if result.Total == 0 {
+		return nil, nil
+	}
+	var tpl whatsapp.RichTemplate
+	if err := mapToStruct(result.Hits[0], &tpl); err != nil {
+		return nil, fmt.Errorf("failed to map rich template document: %w", err)
+	}
+	return &tpl, nil
+}
+
+// List returns rich templates matching the filter, paginated.
+// app_id is required. The default page size is 50; the cap is 500 to keep
+// page payloads bounded for the UI.
+func (r *WhatsAppRichTemplateRepository) List(ctx context.Context, filter whatsapp.RichTemplateFilter) ([]*whatsapp.RichTemplate, int64, error) {
+	if filter.AppID == "" {
+		return nil, 0, fmt.Errorf("app_id is required for listing rich templates")
+	}
+	limit := filter.Limit
+	if limit <= 0 {
+		limit = 50
+	} else if limit > 500 {
+		limit = 500
+	}
+	offset := filter.Offset
+	if offset < 0 {
+		offset = 0
+	}
+
+	must := []map[string]interface{}{
+		{"term": map[string]interface{}{"app_id": filter.AppID}},
+	}
+	if filter.TenantID != "" {
+		must = append(must, map[string]interface{}{"term": map[string]interface{}{"tenant_id": filter.TenantID}})
+	}
+	if filter.Kind != "" {
+		must = append(must, map[string]interface{}{"term": map[string]interface{}{"kind": filter.Kind}})
+	}
+	if filter.Status != "" {
+		must = append(must, map[string]interface{}{"term": map[string]interface{}{"approval_state": filter.Status}})
+	}
+	if filter.NamePrefix != "" {
+		must = append(must, map[string]interface{}{"prefix": map[string]interface{}{"name": filter.NamePrefix}})
+	}
+
+	query := map[string]interface{}{
+		"query": map[string]interface{}{
+			"bool": map[string]interface{}{"must": must},
+		},
+		"sort": []map[string]interface{}{
+			{"updated_at": map[string]interface{}{"order": "desc"}},
+		},
+		"from": offset,
+		"size": limit,
+	}
+
+	result, err := r.base.Search(ctx, query)
+	if err != nil {
+		return nil, 0, err
+	}
+	out := make([]*whatsapp.RichTemplate, 0, len(result.Hits))
+	for _, hit := range result.Hits {
+		var tpl whatsapp.RichTemplate
+		if err := mapToStruct(hit, &tpl); err != nil {
+			// Skip malformed rows rather than failing the whole list — surface
+			// the warning so they can be investigated separately.
+			r.logger.Warn("Failed to map rich template hit", zap.Error(err))
+			continue
+		}
+		out = append(out, &tpl)
+	}
+	return out, result.Total, nil
+}
+
+// Update replaces the document with the given template. Stamps UpdatedAt if
+// the caller has not set it, keeping write semantics consistent across the
+// repository: every Update mutates UpdatedAt.
+func (r *WhatsAppRichTemplateRepository) Update(ctx context.Context, tpl *whatsapp.RichTemplate) error {
+	if tpl == nil || tpl.ID == "" {
+		return fmt.Errorf("rich template missing id")
+	}
+	if tpl.UpdatedAt.IsZero() {
+		tpl.UpdatedAt = time.Now().UTC()
+	}
+	return r.base.Replace(ctx, tpl.ID, tpl)
+}
+
+// Delete removes a template by ID.
+func (r *WhatsAppRichTemplateRepository) Delete(ctx context.Context, id string) error {
+	return r.base.Delete(ctx, id)
+}

--- a/internal/interfaces/http/dto/whatsapp_dto.go
+++ b/internal/interfaces/http/dto/whatsapp_dto.go
@@ -47,18 +47,55 @@ type MetaContactProfile struct {
 
 // MetaInboundMsg represents a single inbound WhatsApp message.
 type MetaInboundMsg struct {
-	From      string               `json:"from"`
-	ID        string               `json:"id"`
-	Timestamp string               `json:"timestamp"`
-	Type      string               `json:"type"` // text, image, video, audio, document, location, contacts, interactive, reaction, order
-	Text      *MetaMsgText         `json:"text,omitempty"`
-	Image     *MetaMsgMedia        `json:"image,omitempty"`
-	Video     *MetaMsgMedia        `json:"video,omitempty"`
-	Audio     *MetaMsgMedia        `json:"audio,omitempty"`
-	Document  *MetaMsgMedia        `json:"document,omitempty"`
-	Location  *MetaMsgLocation     `json:"location,omitempty"`
-	Context   *MetaMsgContext      `json:"context,omitempty"`
-	Referral  *MetaMsgReferral     `json:"referral,omitempty"`
+	From        string               `json:"from"`
+	ID          string               `json:"id"`
+	Timestamp   string               `json:"timestamp"`
+	Type        string               `json:"type"` // text, image, video, audio, document, location, contacts, interactive, button, reaction, order
+	Text        *MetaMsgText         `json:"text,omitempty"`
+	Image       *MetaMsgMedia        `json:"image,omitempty"`
+	Video       *MetaMsgMedia        `json:"video,omitempty"`
+	Audio       *MetaMsgMedia        `json:"audio,omitempty"`
+	Document    *MetaMsgMedia        `json:"document,omitempty"`
+	Location    *MetaMsgLocation     `json:"location,omitempty"`
+	Context     *MetaMsgContext      `json:"context,omitempty"`
+	Referral    *MetaMsgReferral     `json:"referral,omitempty"`
+	Interactive *MetaMsgInteractive  `json:"interactive,omitempty"` // quick-reply / list-reply taps
+	Button      *MetaMsgButton       `json:"button,omitempty"`      // template button taps (URL/QUICK_REPLY)
+	Reaction    *MetaMsgReaction     `json:"reaction,omitempty"`
+}
+
+// MetaMsgInteractive holds quick-reply or list-reply payloads sent by the user.
+// Exactly one of ButtonReply / ListReply is set, determined by Type.
+type MetaMsgInteractive struct {
+	Type        string                       `json:"type"` // "button_reply" | "list_reply"
+	ButtonReply *MetaMsgInteractiveReply     `json:"button_reply,omitempty"`
+	ListReply   *MetaMsgInteractiveListReply `json:"list_reply,omitempty"`
+}
+
+// MetaMsgInteractiveReply is the payload of a quick-reply button tap.
+type MetaMsgInteractiveReply struct {
+	ID    string `json:"id"`    // matches metaButtonReply.ID we sent
+	Title string `json:"title"` // matches metaButtonReply.Title we sent
+}
+
+// MetaMsgInteractiveListReply is the payload of a list-row tap.
+type MetaMsgInteractiveListReply struct {
+	ID          string `json:"id"`
+	Title       string `json:"title"`
+	Description string `json:"description,omitempty"`
+}
+
+// MetaMsgButton is the payload Meta delivers when a recipient taps a template
+// button (URL or QUICK_REPLY); see Meta Cloud API "Received Templates" docs.
+type MetaMsgButton struct {
+	Text    string `json:"text"`    // visible button label
+	Payload string `json:"payload"` // configured payload (QUICK_REPLY) or button URL
+}
+
+// MetaMsgReaction is an inbound reaction (emoji) to a previously-sent message.
+type MetaMsgReaction struct {
+	MessageID string `json:"message_id"`
+	Emoji     string `json:"emoji,omitempty"`
 }
 
 // MetaMsgText is the text content of a message.

--- a/internal/interfaces/http/handlers/click_redirect_handler.go
+++ b/internal/interfaces/http/handlers/click_redirect_handler.go
@@ -1,0 +1,99 @@
+package handlers
+
+import (
+	"context"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+	"github.com/the-monkeys/freerangenotify/internal/domain/analytics"
+	"github.com/the-monkeys/freerangenotify/internal/domain/whatsapp"
+	"github.com/the-monkeys/freerangenotify/internal/infrastructure/repository"
+	"go.uber.org/zap"
+)
+
+// ClickRedirectHandler serves GET /v1/r/:sig — the public landing point
+// for tracked URLs embedded in rich WhatsApp templates. The handler:
+//
+//   1. Verifies the signed payload (HMAC + expiry).
+//   2. Best-effort tracks a `clicked` analytics event.
+//   3. 302-redirects the user to the target URL.
+//
+// Tracking failures are logged but do not block the redirect — the
+// recipient's UX trumps perfect analytics.
+type ClickRedirectHandler struct {
+	signer    *whatsapp.ClickSigner
+	analytics *repository.AnalyticsEventRepository
+	logger    *zap.Logger
+}
+
+// NewClickRedirectHandler wires the handler.
+func NewClickRedirectHandler(signer *whatsapp.ClickSigner, analytics *repository.AnalyticsEventRepository, logger *zap.Logger) *ClickRedirectHandler {
+	return &ClickRedirectHandler{signer: signer, analytics: analytics, logger: logger}
+}
+
+// Handle implements GET /v1/r/:sig.
+//
+// Error responses are deliberately spare HTML so a curious user pasting
+// the link into a browser sees a friendly message instead of JSON noise,
+// while preserving distinct status codes (400/403/410) for observability.
+func (h *ClickRedirectHandler) Handle(c *fiber.Ctx) error {
+	sig := c.Params("sig")
+	if sig == "" {
+		return c.Status(fiber.StatusBadRequest).SendString("missing signature")
+	}
+	payload, err := h.signer.Verify(sig)
+	if err != nil {
+		switch err {
+		case whatsapp.ErrClickExpired:
+			return c.Status(fiber.StatusGone).SendString("This link has expired.")
+		case whatsapp.ErrClickSignature:
+			h.logger.Warn("Click signature mismatch", zap.String("sig_prefix", safePrefix(sig)))
+			return c.Status(fiber.StatusForbidden).SendString("invalid signature")
+		default:
+			return c.Status(fiber.StatusBadRequest).SendString("invalid link")
+		}
+	}
+
+	// Fire-and-forget the analytics write — never block the redirect.
+	if h.analytics != nil {
+		go func(p whatsapp.ClickPayload, ua, ip string) {
+			ev := &analytics.Event{
+				ID:             uuid.NewString(),
+				AppID:          p.AppID,
+				NotificationID: p.NotificationID,
+				EventType:      analytics.EventClicked,
+				Channel:        "whatsapp",
+				Timestamp:      time.Now().UTC(),
+				Metadata: map[string]interface{}{
+					"button_index": p.ButtonIndex,
+					"target_url":   p.TargetURL,
+					"user_agent":   ua,
+					"ip":           ip,
+				},
+			}
+			// Use a fresh context — the Fiber request context is recycled
+			// once the handler returns. context.Background() with a short
+			// timeout keeps the ES write bounded.
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			defer cancel()
+			if err := h.analytics.Track(ctx, ev); err != nil {
+				h.logger.Warn("Click analytics track failed",
+					zap.String("notification_id", p.NotificationID),
+					zap.Error(err))
+			}
+		}(*payload, string(c.Request().Header.UserAgent()), c.IP())
+	}
+
+	return c.Redirect(payload.TargetURL, fiber.StatusFound)
+}
+
+// safePrefix returns up to the first 12 chars of a signature for logging
+// without leaking the full HMAC. Useful for correlating warnings without
+// helping an attacker assemble a valid signature.
+func safePrefix(sig string) string {
+	if len(sig) > 12 {
+		return sig[:12] + "…"
+	}
+	return sig
+}

--- a/internal/interfaces/http/handlers/meta_webhook_handler.go
+++ b/internal/interfaces/http/handlers/meta_webhook_handler.go
@@ -8,28 +8,51 @@ import (
 	"encoding/json"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/the-monkeys/freerangenotify/internal/domain/application"
 	"github.com/the-monkeys/freerangenotify/internal/domain/whatsapp"
 	"github.com/the-monkeys/freerangenotify/internal/interfaces/http/dto"
+	"github.com/the-monkeys/freerangenotify/internal/usecases/services"
 	"go.uber.org/zap"
 )
+
+// wabaCacheTTL is how long the WABA/phone-number-id → app_id lookup table is
+// cached. 5 min keeps the worst-case staleness equal to the Meta template
+// status sync window in the implementation plan.
+const wabaCacheTTL = 5 * time.Minute
 
 // MetaWebhookHandler handles Meta WhatsApp Cloud API webhooks.
 type MetaWebhookHandler struct {
 	whatsappSvc     whatsapp.Service
 	appRepo         application.Repository
-	templateHandler *WhatsAppTemplateHandler // optional, for template status webhooks
-	appSecret       string                  // Meta App Secret for X-Hub-Signature-256 verification
-	verifyToken     string                  // hub.verify_token for webhook subscription registration
-	logger          *zap.Logger
+	templateHandler    *WhatsAppTemplateHandler             // optional, legacy template status webhooks
+	richTemplateSvc    services.WhatsAppRichTemplateService // optional, rich-template status webhooks
+	appSecret          string                               // Meta App Secret for X-Hub-Signature-256 verification
+	verifyToken        string                               // hub.verify_token for webhook subscription registration
+	logger             *zap.Logger
+
+	// WABA / phone-number-id → app_id cache. Avoids an O(N) app scan on every
+	// inbound webhook. Refilled lazily via repopulateLocked() on miss or expiry.
+	cacheMu        sync.RWMutex
+	wabaIndex      map[string]string // waba_id -> app_id
+	phoneIndex     map[string]string // phone_number_id -> app_id
+	cacheExpiresAt time.Time
 }
 
 // SetTemplateHandler wires the template handler for processing template status webhooks.
 func (h *MetaWebhookHandler) SetTemplateHandler(th *WhatsAppTemplateHandler) {
 	h.templateHandler = th
+}
+
+// SetRichTemplateService wires the rich-template service so async
+// message_template_status_update events from Meta update the FRN-side
+// MetaBinding without polling. Optional — if unset, only the legacy
+// templateHandler receives the event.
+func (h *MetaWebhookHandler) SetRichTemplateService(svc services.WhatsAppRichTemplateService) {
+	h.richTemplateSvc = svc
 }
 
 // NewMetaWebhookHandler creates a new Meta webhook handler.
@@ -112,11 +135,26 @@ func (h *MetaWebhookHandler) HandleWebhook(c *fiber.Ctx) error {
 				}
 
 			case "message_template_status_update":
+				rawBytes, _ := json.Marshal(change.Value)
+				var event map[string]interface{}
+				_ = json.Unmarshal(rawBytes, &event)
 				if h.templateHandler != nil {
-					rawBytes, _ := json.Marshal(change.Value)
-					var event map[string]interface{}
-					_ = json.Unmarshal(rawBytes, &event)
 					h.templateHandler.HandleTemplateStatusWebhook(event)
+				}
+				// Forward to the rich-template service so the FRN-side binding
+				// reflects approval transitions without polling.
+				if h.richTemplateSvc != nil {
+					tplName, _ := event["message_template_name"].(string)
+					status, _ := event["event"].(string)
+					reason, _ := event["reason"].(string)
+					if tplName != "" && status != "" {
+						if err := h.richTemplateSvc.ApplyMetaStatus(c.Context(), wabaID, tplName, status, reason); err != nil {
+							h.logger.Warn("Rich template status update failed",
+								zap.String("waba_id", wabaID),
+								zap.String("template", tplName),
+								zap.Error(err))
+						}
+					}
 				}
 
 			default:
@@ -190,6 +228,44 @@ func (h *MetaWebhookHandler) handleInboundMessage(
 				inbound.TextBody = msg.Location.Name
 			}
 		}
+	case "interactive":
+		// Quick-reply or list-row tap on an interactive message we sent.
+		// The button payload / row ID is what callers gave us in
+		// metaButtonReply.ID / metaSectionRow.ID — surfacing it as a typed
+		// field so workflows and the inbox can react without re-parsing.
+		if msg.Interactive != nil {
+			inbound.InteractiveType = msg.Interactive.Type
+			switch msg.Interactive.Type {
+			case "button_reply":
+				if msg.Interactive.ButtonReply != nil {
+					inbound.ReplyID = msg.Interactive.ButtonReply.ID
+					inbound.ReplyTitle = msg.Interactive.ButtonReply.Title
+					inbound.TextBody = msg.Interactive.ButtonReply.Title
+				}
+			case "list_reply":
+				if msg.Interactive.ListReply != nil {
+					inbound.ReplyID = msg.Interactive.ListReply.ID
+					inbound.ReplyTitle = msg.Interactive.ListReply.Title
+					inbound.ReplyDescription = msg.Interactive.ListReply.Description
+					inbound.TextBody = msg.Interactive.ListReply.Title
+				}
+			}
+		}
+	case "button":
+		// Template button tap (URL or QUICK_REPLY). Meta delivers this as a
+		// separate msg.Type "button" with text + payload fields, NOT as
+		// "interactive" — easy to miss.
+		if msg.Button != nil {
+			inbound.InteractiveType = "template_button"
+			inbound.ReplyTitle = msg.Button.Text
+			inbound.ButtonPayload = msg.Button.Payload
+			inbound.TextBody = msg.Button.Text
+		}
+	case "reaction":
+		if msg.Reaction != nil {
+			inbound.ContextMessageID = msg.Reaction.MessageID
+			inbound.ReactionEmoji = msg.Reaction.Emoji
+		}
 	default:
 		// Store raw payload for unsupported types
 		rawBytes, _ := json.Marshal(msg)
@@ -243,31 +319,88 @@ func (h *MetaWebhookHandler) handleStatusUpdate(c *fiber.Ctx, status *dto.MetaSt
 }
 
 // resolveAppID maps a WABA ID + phone number ID to a FreeRangeNotify app.
-// It checks per-app WhatsApp config for matching Meta credentials.
+// Hot path on every inbound webhook; backed by an in-memory cache that is
+// refilled at most every wabaCacheTTL.
 func (h *MetaWebhookHandler) resolveAppID(ctx context.Context, wabaID, phoneNumberID string) string {
-	// TODO: In production, maintain a Redis cache of waba_id→app_id mappings
-	// populated during Embedded Signup (Phase 2). For now, do a brute-force
-	// scan of apps — acceptable at low volume.
-	apps, err := h.appRepo.List(ctx, application.ApplicationFilter{Limit: 500})
-	if err != nil {
+	if appID := h.lookupCached(wabaID, phoneNumberID); appID != "" {
+		return appID
+	}
+
+	// Cache miss or expired — refill and retry under the write lock so that a
+	// burst of webhooks for a freshly-configured WABA doesn't issue N parallel
+	// ES list calls.
+	h.cacheMu.Lock()
+	if appID := h.lookupLocked(wabaID, phoneNumberID); appID != "" && time.Now().Before(h.cacheExpiresAt) {
+		h.cacheMu.Unlock()
+		return appID
+	}
+	if err := h.repopulateLocked(ctx); err != nil {
+		h.cacheMu.Unlock()
 		h.logger.Warn("Failed to list apps for WABA resolution", zap.Error(err))
 		return ""
 	}
+	appID := h.lookupLocked(wabaID, phoneNumberID)
+	h.cacheMu.Unlock()
 
+	if appID == "" {
+		h.logger.Debug("No app found for WABA/phone combo",
+			zap.String("waba_id", wabaID),
+			zap.String("phone_number_id", phoneNumberID))
+	}
+	return appID
+}
+
+// lookupCached returns the cached app_id under a read lock, or "" if the
+// cache is empty / expired / has no match.
+func (h *MetaWebhookHandler) lookupCached(wabaID, phoneNumberID string) string {
+	h.cacheMu.RLock()
+	defer h.cacheMu.RUnlock()
+	if time.Now().After(h.cacheExpiresAt) {
+		return ""
+	}
+	return h.lookupLocked(wabaID, phoneNumberID)
+}
+
+// lookupLocked must be called with cacheMu held (read or write).
+func (h *MetaWebhookHandler) lookupLocked(wabaID, phoneNumberID string) string {
+	if wabaID != "" {
+		if id, ok := h.wabaIndex[wabaID]; ok {
+			return id
+		}
+	}
+	if phoneNumberID != "" {
+		if id, ok := h.phoneIndex[phoneNumberID]; ok {
+			return id
+		}
+	}
+	return ""
+}
+
+// repopulateLocked refreshes the WABA / phone-number-id indexes. Must be
+// called with cacheMu write-locked.
+func (h *MetaWebhookHandler) repopulateLocked(ctx context.Context) error {
+	apps, err := h.appRepo.List(ctx, application.ApplicationFilter{Limit: 500})
+	if err != nil {
+		return err
+	}
+	waba := make(map[string]string, len(apps))
+	phone := make(map[string]string, len(apps))
 	for _, app := range apps {
 		wa := app.Settings.WhatsApp
 		if wa == nil || wa.Provider != "meta" {
 			continue
 		}
-		if wa.MetaWABAID == wabaID || wa.MetaPhoneNumberID == phoneNumberID {
-			return app.AppID
+		if wa.MetaWABAID != "" {
+			waba[wa.MetaWABAID] = app.AppID
+		}
+		if wa.MetaPhoneNumberID != "" {
+			phone[wa.MetaPhoneNumberID] = app.AppID
 		}
 	}
-
-	h.logger.Debug("No app found for WABA/phone combo",
-		zap.String("waba_id", wabaID),
-		zap.String("phone_number_id", phoneNumberID))
-	return ""
+	h.wabaIndex = waba
+	h.phoneIndex = phone
+	h.cacheExpiresAt = time.Now().Add(wabaCacheTTL)
+	return nil
 }
 
 func (h *MetaWebhookHandler) verifySignature(body []byte, sigHeader string) bool {

--- a/internal/interfaces/http/handlers/meta_webhook_handler_test.go
+++ b/internal/interfaces/http/handlers/meta_webhook_handler_test.go
@@ -1,0 +1,256 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/the-monkeys/freerangenotify/internal/domain/application"
+	"github.com/the-monkeys/freerangenotify/internal/domain/whatsapp"
+	"go.uber.org/zap"
+)
+
+// captureService records every InboundMessage HandleInbound was called with so
+// tests can assert what the webhook handler parsed off the wire. All other
+// methods are stubs since only the inbound path is under test here.
+type captureService struct {
+	mu     sync.Mutex
+	calls  []*whatsapp.InboundMessage
+	appIDs []string
+}
+
+func (c *captureService) HandleInbound(_ context.Context, appID string, msg *whatsapp.InboundMessage) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.appIDs = append(c.appIDs, appID)
+	c.calls = append(c.calls, msg)
+	return nil
+}
+func (c *captureService) HandleStatus(context.Context, *whatsapp.DeliveryStatus) error { return nil }
+func (c *captureService) ListMessages(context.Context, *whatsapp.MessageFilter) ([]*whatsapp.InboundMessage, int64, error) {
+	return nil, 0, nil
+}
+func (c *captureService) IsCSWOpen(context.Context, string, string) bool { return false }
+func (c *captureService) ListConversations(context.Context, string, int, int) ([]*whatsapp.Conversation, int64, error) {
+	return nil, 0, nil
+}
+func (c *captureService) Reply(context.Context, string, string, string, string) error { return nil }
+func (c *captureService) MarkRead(context.Context, string, string) error              { return nil }
+
+// staticAppRepo returns a fixed app list for resolveAppID lookups.
+// The remaining Repository methods are unused in the inbound webhook path.
+type staticAppRepo struct {
+	apps      []*application.Application
+	listCalls int
+}
+
+func (r *staticAppRepo) Create(context.Context, *application.Application) error { return nil }
+func (r *staticAppRepo) GetByID(context.Context, string) (*application.Application, error) {
+	return nil, nil
+}
+func (r *staticAppRepo) GetByAPIKey(context.Context, string) (*application.Application, error) {
+	return nil, nil
+}
+func (r *staticAppRepo) Update(context.Context, *application.Application) error { return nil }
+func (r *staticAppRepo) List(context.Context, application.ApplicationFilter) ([]*application.Application, error) {
+	r.listCalls++
+	return r.apps, nil
+}
+func (r *staticAppRepo) Delete(context.Context, string) error                          { return nil }
+func (r *staticAppRepo) RegenerateAPIKey(context.Context, string) (string, error)      { return "", nil }
+
+// postWebhook drives the handler with a JSON body and returns the captured
+// InboundMessage list. Signature verification is disabled in tests (no app
+// secret), so we don't need to compute X-Hub-Signature-256.
+func postWebhook(t *testing.T, body string) (*captureService, *staticAppRepo) {
+	t.Helper()
+	svc := &captureService{}
+	repo := &staticAppRepo{
+		apps: []*application.Application{
+			{
+				AppID: "app-1",
+				Settings: application.Settings{
+					WhatsApp: &application.WhatsAppAppConfig{
+						Provider:          "meta",
+						MetaWABAID:        "WABA_X",
+						MetaPhoneNumberID: "PH_1",
+					},
+				},
+			},
+		},
+	}
+	h := NewMetaWebhookHandler(svc, repo, "" /* no signature check */, "token", zap.NewNop())
+
+	app := fiber.New()
+	app.Post("/webhook", h.HandleWebhook)
+
+	req := httptest.NewRequest("POST", "/webhook", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req, -1)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	return svc, repo
+}
+
+// TestInbound_QuickReplyButton verifies that a button_reply inbound message
+// is parsed to typed fields (ReplyID/ReplyTitle) instead of being dumped
+// into RawPayload. Regression guard for the dropped-button-clicks bug.
+func TestInbound_QuickReplyButton(t *testing.T) {
+	body := mustEncode(t, sampleEnvelope("interactive", map[string]interface{}{
+		"interactive": map[string]interface{}{
+			"type":         "button_reply",
+			"button_reply": map[string]interface{}{"id": "BTN_YES", "title": "Yes"},
+		},
+	}))
+	svc, _ := postWebhook(t, body)
+
+	msg := requireOneCall(t, svc)
+	if msg.InteractiveType != "button_reply" {
+		t.Errorf("InteractiveType: got %q, want button_reply", msg.InteractiveType)
+	}
+	if msg.ReplyID != "BTN_YES" || msg.ReplyTitle != "Yes" {
+		t.Errorf("reply fields: %+v", msg)
+	}
+	if msg.TextBody != "Yes" {
+		t.Errorf("TextBody mirror: got %q, want %q", msg.TextBody, "Yes")
+	}
+}
+
+// TestInbound_ListReply verifies that list-row taps populate the description
+// field in addition to ID/title.
+func TestInbound_ListReply(t *testing.T) {
+	body := mustEncode(t, sampleEnvelope("interactive", map[string]interface{}{
+		"interactive": map[string]interface{}{
+			"type": "list_reply",
+			"list_reply": map[string]interface{}{
+				"id":          "ROW_5",
+				"title":       "Medium",
+				"description": "Best for most users",
+			},
+		},
+	}))
+	svc, _ := postWebhook(t, body)
+
+	msg := requireOneCall(t, svc)
+	if msg.InteractiveType != "list_reply" {
+		t.Errorf("InteractiveType: got %q", msg.InteractiveType)
+	}
+	if msg.ReplyID != "ROW_5" || msg.ReplyTitle != "Medium" || msg.ReplyDescription != "Best for most users" {
+		t.Errorf("list_reply fields not populated: %+v", msg)
+	}
+}
+
+// TestInbound_TemplateButtonTap covers the easily-missed "button" message
+// type that Meta sends for template button (URL/QUICK_REPLY) taps — distinct
+// from "interactive" message types.
+func TestInbound_TemplateButtonTap(t *testing.T) {
+	body := mustEncode(t, sampleEnvelope("button", map[string]interface{}{
+		"button": map[string]interface{}{
+			"text":    "Track order",
+			"payload": "TRACK_42",
+		},
+	}))
+	svc, _ := postWebhook(t, body)
+
+	msg := requireOneCall(t, svc)
+	if msg.InteractiveType != "template_button" {
+		t.Errorf("InteractiveType: got %q, want template_button", msg.InteractiveType)
+	}
+	if msg.ButtonPayload != "TRACK_42" || msg.ReplyTitle != "Track order" {
+		t.Errorf("button fields: %+v", msg)
+	}
+}
+
+// TestResolveAppID_CacheHit ensures the WABA cache prevents repeat ES list
+// calls for back-to-back webhooks. Critical for any non-trivial inbound load.
+func TestResolveAppID_CacheHit(t *testing.T) {
+	body := mustEncode(t, sampleEnvelope("text", map[string]interface{}{
+		"text": map[string]interface{}{"body": "hi"},
+	}))
+	svc, repo := postWebhook(t, body)
+	_ = requireOneCall(t, svc)
+
+	// Reuse the same handler by sending a second webhook through it — drive a
+	// fresh request against the same handler instance. The simplest way is
+	// constructing the handler directly so we can assert listCalls.
+	h := NewMetaWebhookHandler(&captureService{}, repo, "", "token", zap.NewNop())
+	app := fiber.New()
+	app.Post("/webhook", h.HandleWebhook)
+	for i := 0; i < 3; i++ {
+		req := httptest.NewRequest("POST", "/webhook", bytes.NewBufferString(body))
+		req.Header.Set("Content-Type", "application/json")
+		if _, err := app.Test(req, -1); err != nil {
+			t.Fatalf("test %d: %v", i, err)
+		}
+	}
+	if repo.listCalls != 1+1 { // 1 from initial postWebhook + 1 from the burst (cache absorbs the rest)
+		t.Errorf("expected exactly 2 list calls (1 per handler), got %d", repo.listCalls)
+	}
+}
+
+// --- helpers ---
+
+func sampleEnvelope(msgType string, extra map[string]interface{}) map[string]interface{} {
+	msg := map[string]interface{}{
+		"from":      "15551234567",
+		"id":        "wamid.ABC",
+		"timestamp": "1700000000",
+		"type":      msgType,
+	}
+	for k, v := range extra {
+		msg[k] = v
+	}
+	return map[string]interface{}{
+		"object": "whatsapp_business_account",
+		"entry": []interface{}{
+			map[string]interface{}{
+				"id": "WABA_X",
+				"changes": []interface{}{
+					map[string]interface{}{
+						"field": "messages",
+						"value": map[string]interface{}{
+							"messaging_product": "whatsapp",
+							"metadata": map[string]interface{}{
+								"phone_number_id": "PH_1",
+							},
+							"messages": []interface{}{msg},
+							"contacts": []interface{}{
+								map[string]interface{}{
+									"wa_id":   "15551234567",
+									"profile": map[string]interface{}{"name": "Asha"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func mustEncode(t *testing.T, v interface{}) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(b)
+}
+
+func requireOneCall(t *testing.T, svc *captureService) *whatsapp.InboundMessage {
+	t.Helper()
+	svc.mu.Lock()
+	defer svc.mu.Unlock()
+	if len(svc.calls) != 1 {
+		t.Fatalf("expected 1 inbound call, got %d", len(svc.calls))
+	}
+	return svc.calls[0]
+}

--- a/internal/interfaces/http/handlers/twilio_content_status_handler.go
+++ b/internal/interfaces/http/handlers/twilio_content_status_handler.go
@@ -1,0 +1,49 @@
+package handlers
+
+import (
+	"github.com/gofiber/fiber/v2"
+	"github.com/the-monkeys/freerangenotify/internal/usecases/services"
+	pkgerrors "github.com/the-monkeys/freerangenotify/pkg/errors"
+	"go.uber.org/zap"
+)
+
+// TwilioContentStatusHandler receives Twilio Content API approval status
+// webhooks. Twilio POSTs application/x-www-form-urlencoded bodies with at
+// least `ContentSid`, `Status`, and optionally `RejectionReason`. We map
+// those onto the FRN-side TwilioBinding via the rich template service.
+//
+// Twilio webhooks should be authenticated via X-Twilio-Signature; the
+// validation is delegated to a middleware so this handler stays focused
+// on event processing.
+type TwilioContentStatusHandler struct {
+	svc    services.WhatsAppRichTemplateService
+	logger *zap.Logger
+}
+
+// NewTwilioContentStatusHandler creates a new handler.
+func NewTwilioContentStatusHandler(svc services.WhatsAppRichTemplateService, logger *zap.Logger) *TwilioContentStatusHandler {
+	return &TwilioContentStatusHandler{svc: svc, logger: logger}
+}
+
+// Handle implements POST /v1/webhooks/twilio/content-status. Returns 200
+// even when the ContentSid is unknown to avoid Twilio retries flooding the
+// log for templates created outside FRN.
+func (h *TwilioContentStatusHandler) Handle(c *fiber.Ctx) error {
+	contentSid := c.FormValue("ContentSid")
+	status := c.FormValue("Status")
+	reason := c.FormValue("RejectionReason")
+
+	if contentSid == "" || status == "" {
+		return pkgerrors.BadRequest("ContentSid and Status are required")
+	}
+
+	if err := h.svc.ApplyTwilioStatus(c.Context(), contentSid, status, reason); err != nil {
+		h.logger.Warn("Twilio status apply failed",
+			zap.String("content_sid", contentSid),
+			zap.String("status", status),
+			zap.Error(err))
+		// Still return 200 so Twilio doesn't retry — the error is logged
+		// and human-investigatable.
+	}
+	return c.SendStatus(fiber.StatusOK)
+}

--- a/internal/interfaces/http/handlers/twilio_inbound_webhook_handler.go
+++ b/internal/interfaces/http/handlers/twilio_inbound_webhook_handler.go
@@ -1,0 +1,275 @@
+package handlers
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/base64"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/the-monkeys/freerangenotify/internal/domain/application"
+	"github.com/the-monkeys/freerangenotify/internal/domain/whatsapp"
+	"go.uber.org/zap"
+)
+
+// TwilioInboundWebhookHandler receives inbound WhatsApp messages (replies,
+// button taps, list selections) from Twilio's Programmable Messaging
+// webhook. Twilio POSTs application/x-www-form-urlencoded bodies with
+// fields like:
+//
+//	MessageSid, AccountSid, From (whatsapp:+...), To (whatsapp:+...),
+//	Body, ButtonText, ButtonPayload, ListId, OriginalRepliedMessageSid,
+//	NumMedia, MediaUrl0, ...
+//
+// This handler verifies X-Twilio-Signature (HMAC-SHA1 over the request
+// URL + sorted form fields, base64-encoded), resolves the target FRN app
+// by matching `To` against application.Settings.WhatsApp.FromNumber, and
+// forwards a normalised whatsapp.InboundMessage to whatsapp.Service which
+// already handles workflow event emission (whatsapp.button_clicked, etc.)
+// per WHATSAPP_RICH_INTERACTIVE_PLAN.md §6.
+//
+// Always returns HTTP 200 so Twilio does not retry. Failures are logged.
+type TwilioInboundWebhookHandler struct {
+	whatsappSvc whatsapp.Service
+	appRepo     application.Repository
+	authToken   string
+	logger      *zap.Logger
+
+	// app lookup cache keyed by normalised "to_number" (without
+	// "whatsapp:" prefix). Refreshed on miss with a short TTL.
+	cacheMu        sync.RWMutex
+	toIndex        map[string]string
+	cacheExpiresAt time.Time
+}
+
+const twilioInboundCacheTTL = 60 * time.Second
+
+// NewTwilioInboundWebhookHandler constructs a Twilio inbound webhook
+// handler. authToken is the Twilio account auth token used to validate
+// signatures; an empty token disables verification (with a warning log
+// per request) and is intended for local development only.
+func NewTwilioInboundWebhookHandler(
+	whatsappSvc whatsapp.Service,
+	appRepo application.Repository,
+	authToken string,
+	logger *zap.Logger,
+) *TwilioInboundWebhookHandler {
+	return &TwilioInboundWebhookHandler{
+		whatsappSvc: whatsappSvc,
+		appRepo:     appRepo,
+		authToken:   authToken,
+		logger:      logger,
+		toIndex:     map[string]string{},
+	}
+}
+
+// Handle implements POST /v1/webhooks/twilio/whatsapp.
+func (h *TwilioInboundWebhookHandler) Handle(c *fiber.Ctx) error {
+	// Capture the raw form values up front; Fiber parses them lazily and
+	// signature validation must see the same key/value set Twilio signed.
+	form, err := c.MultipartForm()
+	if err != nil {
+		// Twilio sends application/x-www-form-urlencoded by default. Fall
+		// back to FormValue accessors below.
+		form = nil
+	}
+	values := collectFormValues(c, form)
+
+	if h.authToken == "" {
+		h.logger.Warn("Twilio inbound webhook signature verification disabled (no auth token configured)")
+	} else {
+		sig := c.Get("X-Twilio-Signature")
+		fullURL := buildTwilioSignatureURL(c)
+		if !validateTwilioSignature(h.authToken, fullURL, values, sig) {
+			h.logger.Warn("Twilio inbound webhook signature rejected",
+				zap.String("from", values["From"]),
+				zap.String("to", values["To"]))
+			return c.SendStatus(fiber.StatusForbidden)
+		}
+	}
+
+	to := strings.TrimPrefix(values["To"], "whatsapp:")
+	from := strings.TrimPrefix(values["From"], "whatsapp:")
+	if from == "" {
+		// Nothing actionable; ack.
+		return c.SendStatus(fiber.StatusOK)
+	}
+
+	appID := h.resolveAppIDByTo(c.Context(), to)
+	if appID == "" {
+		h.logger.Warn("Twilio inbound webhook: no app matched 'To' number",
+			zap.String("to", to))
+		return c.SendStatus(fiber.StatusOK)
+	}
+
+	msg := buildInboundFromTwilio(appID, from, values)
+	if err := h.whatsappSvc.HandleInbound(c.Context(), appID, msg); err != nil {
+		h.logger.Error("Twilio inbound: HandleInbound failed",
+			zap.String("app_id", appID),
+			zap.String("from", from),
+			zap.Error(err))
+	}
+	return c.SendStatus(fiber.StatusOK)
+}
+
+// resolveAppIDByTo looks up the FRN app whose Twilio FromNumber matches
+// the inbound `To` field. Results are cached for a short TTL.
+func (h *TwilioInboundWebhookHandler) resolveAppIDByTo(ctx context.Context, to string) string {
+	if to == "" {
+		return ""
+	}
+	h.cacheMu.RLock()
+	if time.Now().Before(h.cacheExpiresAt) {
+		if id, ok := h.toIndex[to]; ok {
+			h.cacheMu.RUnlock()
+			return id
+		}
+	}
+	h.cacheMu.RUnlock()
+
+	// Refresh cache.
+	h.cacheMu.Lock()
+	defer h.cacheMu.Unlock()
+	if time.Now().Before(h.cacheExpiresAt) {
+		if id, ok := h.toIndex[to]; ok {
+			return id
+		}
+	}
+	apps, err := h.appRepo.List(ctx, application.ApplicationFilter{Limit: 500})
+	if err != nil {
+		h.logger.Warn("Twilio inbound: app list failed", zap.Error(err))
+		return ""
+	}
+	idx := make(map[string]string, len(apps))
+	for _, app := range apps {
+		wa := app.Settings.WhatsApp
+		if wa == nil {
+			continue
+		}
+		if wa.FromNumber != "" {
+			idx[strings.TrimPrefix(wa.FromNumber, "whatsapp:")] = app.AppID
+		}
+	}
+	h.toIndex = idx
+	h.cacheExpiresAt = time.Now().Add(twilioInboundCacheTTL)
+	return idx[to]
+}
+
+// buildInboundFromTwilio normalises Twilio's flat form fields into the
+// FRN-internal InboundMessage shape. Field mapping:
+//
+//   - ButtonPayload present → InteractiveType "template_button"
+//   - ButtonText present → InteractiveType "button_reply"
+//   - ListId present → InteractiveType "list_reply"
+//   - Otherwise → MessageType "text"
+func buildInboundFromTwilio(appID, from string, v map[string]string) *whatsapp.InboundMessage {
+	now := time.Now().UTC()
+	msg := &whatsapp.InboundMessage{
+		AppID:            appID,
+		ContactWAID:      from,
+		Direction:        whatsapp.DirectionInbound,
+		MetaMessageID:    v["MessageSid"],
+		Timestamp:        now,
+		CreatedAt:        now,
+		ContextMessageID: v["OriginalRepliedMessageSid"],
+		TextBody:         v["Body"],
+		RawPayload:       toInterfaceMap(v),
+	}
+
+	switch {
+	case v["ButtonPayload"] != "":
+		msg.MessageType = "interactive"
+		msg.InteractiveType = "template_button"
+		msg.ButtonPayload = v["ButtonPayload"]
+		msg.ReplyTitle = v["ButtonText"]
+	case v["ButtonText"] != "":
+		msg.MessageType = "interactive"
+		msg.InteractiveType = "button_reply"
+		msg.ReplyTitle = v["ButtonText"]
+		msg.ReplyID = v["ButtonText"]
+	case v["ListId"] != "":
+		msg.MessageType = "interactive"
+		msg.InteractiveType = "list_reply"
+		msg.ReplyID = v["ListId"]
+		msg.ReplyTitle = v["ListTitle"]
+		msg.ReplyDescription = v["ListDescription"]
+	default:
+		msg.MessageType = "text"
+	}
+	return msg
+}
+
+// validateTwilioSignature implements Twilio's standard signature scheme:
+// HMAC-SHA1 over (fullURL + sorted-by-key concatenation of form keys+values),
+// base64-encoded. See https://www.twilio.com/docs/usage/webhooks/webhooks-security.
+func validateTwilioSignature(authToken, fullURL string, values map[string]string, signature string) bool {
+	if signature == "" {
+		return false
+	}
+	keys := make([]string, 0, len(values))
+	for k := range values {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var sb strings.Builder
+	sb.WriteString(fullURL)
+	for _, k := range keys {
+		sb.WriteString(k)
+		sb.WriteString(values[k])
+	}
+	mac := hmac.New(sha1.New, []byte(authToken))
+	mac.Write([]byte(sb.String()))
+	expected := base64.StdEncoding.EncodeToString(mac.Sum(nil))
+	return hmac.Equal([]byte(expected), []byte(signature))
+}
+
+// buildTwilioSignatureURL reconstructs the absolute URL Twilio used when
+// signing. Behind a TLS-terminating proxy callers MUST forward the
+// X-Forwarded-Proto / X-Forwarded-Host headers or pass an explicit
+// public URL — Twilio's signature is URL-sensitive.
+func buildTwilioSignatureURL(c *fiber.Ctx) string {
+	scheme := c.Get("X-Forwarded-Proto")
+	if scheme == "" {
+		scheme = c.Protocol()
+	}
+	host := c.Get("X-Forwarded-Host")
+	if host == "" {
+		host = c.Hostname()
+	}
+	return scheme + "://" + host + c.OriginalURL()
+}
+
+// collectFormValues extracts all form fields (multipart or urlencoded)
+// into a flat string map. Multi-value fields are joined by comma — none
+// of Twilio's WhatsApp webhook fields are repeated in practice.
+func collectFormValues(c *fiber.Ctx, mf interface{}) map[string]string {
+	out := map[string]string{}
+	// Common Twilio fields we definitely want even if multipart parsing
+	// failed; FormValue falls back to urlencoded body parsing.
+	for _, k := range []string{
+		"MessageSid", "AccountSid", "From", "To", "Body",
+		"ButtonText", "ButtonPayload", "ListId", "ListTitle",
+		"ListDescription", "OriginalRepliedMessageSid", "NumMedia",
+		"MediaUrl0", "MediaContentType0", "ProfileName", "WaId",
+	} {
+		if v := c.FormValue(k); v != "" {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+// toInterfaceMap shallow-copies a string map into the map[string]interface{}
+// shape expected by InboundMessage.RawPayload.
+func toInterfaceMap(in map[string]string) map[string]interface{} {
+	out := make(map[string]interface{}, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}

--- a/internal/interfaces/http/handlers/whatsapp_rich_template_handler.go
+++ b/internal/interfaces/http/handlers/whatsapp_rich_template_handler.go
@@ -1,0 +1,165 @@
+package handlers
+
+import (
+	"github.com/gofiber/fiber/v2"
+	"github.com/the-monkeys/freerangenotify/internal/domain/whatsapp"
+	"github.com/the-monkeys/freerangenotify/internal/usecases/services"
+	pkgerrors "github.com/the-monkeys/freerangenotify/pkg/errors"
+	"go.uber.org/zap"
+)
+
+// WhatsAppRichTemplateHandler is the HTTP surface for the FRN-internal rich
+// template store (`/v1/whatsapp/rich-templates`). Differs from
+// WhatsAppTemplateHandler which is a thin shim over Meta Graph API for the
+// legacy templates collection — this handler operates on the typed
+// RichTemplate authored in FRN and submitted to providers behind the scenes.
+type WhatsAppRichTemplateHandler struct {
+	svc    services.WhatsAppRichTemplateService
+	logger *zap.Logger
+}
+
+// NewWhatsAppRichTemplateHandler wires the handler. The service handles all
+// provider-side I/O, validation, and persistence so this layer stays small
+// and focused on request parsing and response shaping.
+func NewWhatsAppRichTemplateHandler(svc services.WhatsAppRichTemplateService, logger *zap.Logger) *WhatsAppRichTemplateHandler {
+	return &WhatsAppRichTemplateHandler{svc: svc, logger: logger}
+}
+
+// Create handles POST /v1/whatsapp/rich-templates.
+//
+// Body shape mirrors whatsapp.RichTemplate (minus IDs / timestamps the
+// service stamps). Validation errors are returned as 400 with the full
+// field-level error list so the UI can highlight specific fields.
+func (h *WhatsAppRichTemplateHandler) Create(c *fiber.Ctx) error {
+	appID, ok := c.Locals("app_id").(string)
+	if !ok || appID == "" {
+		return pkgerrors.Unauthorized("Missing app context")
+	}
+
+	var body whatsapp.RichTemplate
+	if err := c.BodyParser(&body); err != nil {
+		return pkgerrors.BadRequest("Invalid JSON body: " + err.Error())
+	}
+	// Always enforce the app context from the API key — never trust the
+	// body. Tenant scoping comes from the application record.
+	body.AppID = appID
+	if tenantID, ok := c.Locals("tenant_id").(string); ok {
+		body.TenantID = tenantID
+	}
+
+	tpl, err := h.svc.Create(c.Context(), &body)
+	if err != nil {
+		if verrs, isValidation := err.(whatsapp.ValidationErrors); isValidation {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+				"success": false,
+				"error":   "Template validation failed",
+				"details": verrs,
+			})
+		}
+		return pkgerrors.New(pkgerrors.ErrCodeInternal, err.Error())
+	}
+	return c.Status(fiber.StatusCreated).JSON(fiber.Map{"success": true, "data": tpl})
+}
+
+// List handles GET /v1/whatsapp/rich-templates with optional query filters:
+//   kind, status, name_prefix, limit, offset.
+// app_id is enforced from the API key context.
+func (h *WhatsAppRichTemplateHandler) List(c *fiber.Ctx) error {
+	appID, ok := c.Locals("app_id").(string)
+	if !ok || appID == "" {
+		return pkgerrors.Unauthorized("Missing app context")
+	}
+	filter := whatsapp.RichTemplateFilter{
+		AppID:      appID,
+		Kind:       c.Query("kind"),
+		Status:     c.Query("status"),
+		NamePrefix: c.Query("name_prefix"),
+		Limit:      c.QueryInt("limit"),
+		Offset:     c.QueryInt("offset"),
+	}
+	if tenantID, ok := c.Locals("tenant_id").(string); ok {
+		filter.TenantID = tenantID
+	}
+	tpls, total, err := h.svc.List(c.Context(), filter)
+	if err != nil {
+		return pkgerrors.New(pkgerrors.ErrCodeInternal, err.Error())
+	}
+	return c.JSON(fiber.Map{"success": true, "data": tpls, "total": total})
+}
+
+// Get handles GET /v1/whatsapp/rich-templates/:id.
+func (h *WhatsAppRichTemplateHandler) Get(c *fiber.Ctx) error {
+	appID, id, err := h.scopedID(c)
+	if err != nil {
+		return err
+	}
+	tpl, err := h.svc.Get(c.Context(), appID, id)
+	if err != nil {
+		return pkgerrors.NotFound("rich_template", id)
+	}
+	return c.JSON(fiber.Map{"success": true, "data": tpl})
+}
+
+// Delete handles DELETE /v1/whatsapp/rich-templates/:id.
+func (h *WhatsAppRichTemplateHandler) Delete(c *fiber.Ctx) error {
+	appID, id, err := h.scopedID(c)
+	if err != nil {
+		return err
+	}
+	if err := h.svc.Delete(c.Context(), appID, id); err != nil {
+		return pkgerrors.New(pkgerrors.ErrCodeInternal, err.Error())
+	}
+	return c.JSON(fiber.Map{"success": true, "message": "Template deleted"})
+}
+
+// Sync handles POST /v1/whatsapp/rich-templates/:id/sync — explicit pull of
+// Meta's current approval state. Cheap fallback for when the webhook is not
+// reachable during local development.
+func (h *WhatsAppRichTemplateHandler) Sync(c *fiber.Ctx) error {
+	appID, id, err := h.scopedID(c)
+	if err != nil {
+		return err
+	}
+	tpl, err := h.svc.SyncApproval(c.Context(), appID, id)
+	if err != nil {
+		return pkgerrors.New(pkgerrors.ErrCodeInternal, err.Error())
+	}
+	return c.JSON(fiber.Map{"success": true, "data": tpl})
+}
+
+// Preview handles GET /v1/whatsapp/rich-templates/:id/preview — returns the
+// authoring JSON the service would submit to Meta. Used by the UI side-by-
+// side renderer so authors see exactly what will land at Meta before they
+// commit to the submission round-trip.
+func (h *WhatsAppRichTemplateHandler) Preview(c *fiber.Ctx) error {
+	appID, id, err := h.scopedID(c)
+	if err != nil {
+		return err
+	}
+	// Optional variables — UI passes them via JSON body for richer preview.
+	var body struct {
+		Variables map[string]string `json:"variables"`
+	}
+	_ = c.BodyParser(&body)
+
+	preview, err := h.svc.Preview(c.Context(), appID, id, body.Variables)
+	if err != nil {
+		return pkgerrors.NotFound("rich_template", id)
+	}
+	return c.JSON(fiber.Map{"success": true, "data": preview})
+}
+
+// scopedID is the common preamble: pull app_id from the API key context and
+// :id from the URL, returning an Unauthorized when the context is missing.
+// Keeps every handler method 2 lines shorter and consistent in error shape.
+func (h *WhatsAppRichTemplateHandler) scopedID(c *fiber.Ctx) (string, string, error) {
+	appID, ok := c.Locals("app_id").(string)
+	if !ok || appID == "" {
+		return "", "", pkgerrors.Unauthorized("Missing app context")
+	}
+	id := c.Params("id")
+	if id == "" {
+		return "", "", pkgerrors.BadRequest("template id is required")
+	}
+	return appID, id, nil
+}

--- a/internal/interfaces/http/routes/routes.go
+++ b/internal/interfaces/http/routes/routes.go
@@ -83,6 +83,24 @@ func setupPublicRoutes(v1 fiber.Router, c *container.Container) {
 		metaWH.Get("/whatsapp", c.MetaWebhookHandler.VerifyWebhook)
 		metaWH.Post("/whatsapp", c.MetaWebhookHandler.HandleWebhook)
 	}
+
+	// Twilio Content API approval status webhook (public; should be guarded
+	// by X-Twilio-Signature middleware in production deployments).
+	if c.TwilioContentStatusHandler != nil {
+		v1.Post("/webhooks/twilio/content-status", c.TwilioContentStatusHandler.Handle)
+	}
+
+	// Twilio inbound WhatsApp webhook (replies, button taps, list selects).
+	// Signature is verified inside the handler using the Twilio auth token.
+	if c.TwilioInboundWebhookHandler != nil {
+		v1.Post("/webhooks/twilio/whatsapp", c.TwilioInboundWebhookHandler.Handle)
+	}
+
+	// Click attribution redirect (public, signed payload). Intentionally
+	// outside any auth group so WhatsApp recipients can tap the link.
+	if c.ClickRedirectHandler != nil {
+		v1.Get("/r/:sig", c.ClickRedirectHandler.Handle)
+	}
 }
 
 // setupProtectedRoutes configures routes that require API key authentication
@@ -241,6 +259,20 @@ func setupProtectedRoutes(v1 fiber.Router, c *container.Container) {
 		waTpl.Get("/:name", c.WhatsAppTemplateHandler.GetTemplate)
 		waTpl.Delete("/:name", c.WhatsAppTemplateHandler.DeleteTemplate)
 		waTpl.Post("/:name/sync", c.WhatsAppTemplateHandler.SyncTemplate)
+	}
+
+	// ── WhatsApp Rich-Template Authoring ──
+	// Typed carousel / coupon / cta_url / quick_reply / list templates.
+	// Submitted to Meta automatically on Create; ApprovalState reflects Meta status.
+	if c.WhatsAppRichTemplateHandler != nil {
+		waRich := v1.Group("/whatsapp/rich-templates")
+		applyAuth(waRich)
+		waRich.Post("/", c.WhatsAppRichTemplateHandler.Create)
+		waRich.Get("/", c.WhatsAppRichTemplateHandler.List)
+		waRich.Get("/:id", c.WhatsAppRichTemplateHandler.Get)
+		waRich.Delete("/:id", c.WhatsAppRichTemplateHandler.Delete)
+		waRich.Post("/:id/sync", c.WhatsAppRichTemplateHandler.Sync)
+		waRich.Post("/:id/preview", c.WhatsAppRichTemplateHandler.Preview)
 	}
 
 	// ── Twilio Content Template Management ──

--- a/internal/usecases/services/whatsapp_rich_meta_payload.go
+++ b/internal/usecases/services/whatsapp_rich_meta_payload.go
@@ -1,0 +1,229 @@
+package services
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/the-monkeys/freerangenotify/internal/domain/whatsapp"
+)
+
+// metaAuthoringPayload converts an FRN RichTemplate into the JSON shape
+// Meta's POST /{waba_id}/message_templates expects. This is intentionally
+// the *authoring* shape — different from the runtime template message JSON
+// the Meta provider builds for send-time (see meta_whatsapp_provider.go).
+//
+// Key differences vs. send-time:
+//   * Component types are UPPERCASE ("BODY" not "body").
+//   * BODY/HEADER text components carry an `example` field so Meta can
+//     review with real-looking content; we generate placeholders if the
+//     authored template has variables but no example.
+//   * Carousel header components use `format` ("IMAGE"/"VIDEO") rather than
+//     inline media; the sample URL goes in example.header_handle.
+//   * Buttons live inside a single "BUTTONS" component, not as separate
+//     components with sub_type/index.
+func metaAuthoringPayload(t *whatsapp.RichTemplate) map[string]interface{} {
+	out := map[string]interface{}{
+		"name":     t.Name,
+		"language": t.Language,
+		"category": t.Category,
+	}
+	components := []map[string]interface{}{}
+
+	if t.Header != nil {
+		if h := metaAuthHeaderComponent(t.Header); h != nil {
+			components = append(components, h)
+		}
+	}
+	if t.Body != "" {
+		components = append(components, metaAuthBodyComponent(t.Body))
+	}
+	if t.Footer != "" {
+		components = append(components, map[string]interface{}{"type": "FOOTER", "text": t.Footer})
+	}
+	buttons := t.Buttons
+	// KindCouponCode stores the code on the template (not as a Button), since
+	// the user authors "use code X" once and never wires a button matrix.
+	// Synthesise the COPY_CODE button here so Meta sees the expected
+	// BUTTONS component shape.
+	if t.Kind == whatsapp.KindCouponCode && t.CouponCode != "" {
+		buttons = append(buttons, whatsapp.Button{
+			Type:       whatsapp.ButtonCopyCode,
+			Text:       "Copy code",
+			CouponCode: t.CouponCode,
+		})
+	}
+	if len(buttons) > 0 {
+		components = append(components, metaAuthButtonsComponent(buttons))
+	}
+	if t.Kind == whatsapp.KindCarousel && len(t.Cards) > 0 {
+		components = append(components, metaAuthCarouselComponent(t.Cards))
+	}
+
+	out["components"] = components
+	return out
+}
+
+// metaAuthHeaderComponent renders a HEADER for the top-level template. For
+// media headers Meta wants `format` + an example handle (the public URL
+// works for the initial submission; for production media you'd upload via
+// the Resumable Upload API and use its handle — out of scope here).
+func metaAuthHeaderComponent(h *whatsapp.Header) map[string]interface{} {
+	switch {
+	case h.Text != "":
+		comp := map[string]interface{}{"type": "HEADER", "format": "TEXT", "text": h.Text}
+		if hasVariablePlaceholders(h.Text) {
+			comp["example"] = map[string]interface{}{"header_text": []string{"Example"}}
+		}
+		return comp
+	case h.ImageURL != "":
+		return map[string]interface{}{
+			"type":   "HEADER",
+			"format": "IMAGE",
+			"example": map[string]interface{}{
+				"header_handle": []string{h.ImageURL},
+			},
+		}
+	case h.VideoURL != "":
+		return map[string]interface{}{
+			"type":   "HEADER",
+			"format": "VIDEO",
+			"example": map[string]interface{}{
+				"header_handle": []string{h.VideoURL},
+			},
+		}
+	case h.DocumentURL != "":
+		return map[string]interface{}{
+			"type":   "HEADER",
+			"format": "DOCUMENT",
+			"example": map[string]interface{}{
+				"header_handle": []string{h.DocumentURL},
+			},
+		}
+	}
+	return nil
+}
+
+// metaAuthBodyComponent emits a BODY component with placeholder examples
+// when the body contains {{n}} variables. Meta's reviewer requires example
+// values for every positional variable so an empty example matrix is a
+// rejection trigger.
+func metaAuthBodyComponent(body string) map[string]interface{} {
+	comp := map[string]interface{}{"type": "BODY", "text": body}
+	if matrix := exampleVarMatrix(body); len(matrix) > 0 {
+		comp["example"] = map[string]interface{}{"body_text": [][]string{matrix}}
+	}
+	return comp
+}
+
+// metaAuthButtonsComponent groups all buttons into a single BUTTONS
+// component per Meta's authoring schema. Each button's per-type fields are
+// pulled in line.
+func metaAuthButtonsComponent(buttons []whatsapp.Button) map[string]interface{} {
+	out := make([]map[string]interface{}, 0, len(buttons))
+	for _, b := range buttons {
+		out = append(out, metaAuthOneButton(b))
+	}
+	return map[string]interface{}{"type": "BUTTONS", "buttons": out}
+}
+
+// metaAuthOneButton emits a single button entry. Caller decides where it
+// lives (top-level BUTTONS or a carousel card BUTTONS).
+func metaAuthOneButton(b whatsapp.Button) map[string]interface{} {
+	out := map[string]interface{}{
+		"type": string(b.Type),
+		"text": b.Text,
+	}
+	switch b.Type {
+	case whatsapp.ButtonURL:
+		out["url"] = b.URL
+		if hasVariablePlaceholders(b.URL) {
+			example := b.Example
+			if example == "" {
+				// Meta requires an example URL for variable-suffixed URLs.
+				// Substitute a sample so submission does not reject.
+				example = strings.ReplaceAll(b.URL, "{{1}}", "example")
+			}
+			out["example"] = []string{example}
+		}
+	case whatsapp.ButtonPhone:
+		out["phone_number"] = b.PhoneNumber
+	case whatsapp.ButtonCopyCode:
+		out["example"] = b.CouponCode
+	case whatsapp.ButtonQuickReply:
+		// QUICK_REPLY only needs text; payload is bound at send-time.
+	}
+	return out
+}
+
+// metaAuthCarouselComponent emits the carousel component for a carousel
+// template. Each card becomes its own components array.
+func metaAuthCarouselComponent(cards []whatsapp.CarouselCard) map[string]interface{} {
+	out := make([]map[string]interface{}, 0, len(cards))
+	for _, card := range cards {
+		comps := []map[string]interface{}{}
+		switch {
+		case card.HeaderImageURL != "":
+			comps = append(comps, map[string]interface{}{
+				"type":    "HEADER",
+				"format":  "IMAGE",
+				"example": map[string]interface{}{"header_handle": []string{card.HeaderImageURL}},
+			})
+		case card.HeaderVideoURL != "":
+			comps = append(comps, map[string]interface{}{
+				"type":    "HEADER",
+				"format":  "VIDEO",
+				"example": map[string]interface{}{"header_handle": []string{card.HeaderVideoURL}},
+			})
+		}
+		if card.Body != "" {
+			body := map[string]interface{}{"type": "BODY", "text": card.Body}
+			matrix := card.Variables
+			if matrix == nil {
+				matrix = exampleVarMatrix(card.Body)
+			}
+			if len(matrix) > 0 {
+				body["example"] = map[string]interface{}{"body_text": [][]string{matrix}}
+			}
+			comps = append(comps, body)
+		}
+		if len(card.Buttons) > 0 {
+			comps = append(comps, metaAuthButtonsComponent(card.Buttons))
+		}
+		out = append(out, map[string]interface{}{"components": comps})
+	}
+	return map[string]interface{}{"type": "CAROUSEL", "cards": out}
+}
+
+// varRE here is the same shape as the validator's, duplicated to keep the
+// services package independent of internal validator helpers. If we add a
+// third copy, lift to a shared helper.
+var varRE = regexp.MustCompile(`\{\{\s*(\d+)\s*\}\}`)
+
+// hasVariablePlaceholders is a fast check used to decide whether to emit an
+// `example` field on body/header/url-button components.
+func hasVariablePlaceholders(s string) bool { return varRE.MatchString(s) }
+
+// exampleVarMatrix returns ["Sample1","Sample2",…] sized to the maximum
+// variable index in s. Meta wants one example per positional variable so
+// this is the minimum shape that satisfies submission review.
+func exampleVarMatrix(s string) []string {
+	matches := varRE.FindAllStringSubmatch(s, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	max := 0
+	for _, m := range matches {
+		n := 0
+		for _, ch := range m[1] {
+			n = n*10 + int(ch-'0')
+		}
+		if n > max {
+			max = n
+		}
+	}
+	out := make([]string, max)
+	for i := range out {
+		out[i] = "sample"
+	}
+	return out
+}

--- a/internal/usecases/services/whatsapp_rich_meta_upload.go
+++ b/internal/usecases/services/whatsapp_rich_meta_upload.go
@@ -1,0 +1,292 @@
+package services
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/the-monkeys/freerangenotify/internal/domain/whatsapp"
+)
+
+// uploadCarouselHeaderMedia uploads every distinct carousel-header media URL
+// on `tpl` to Meta's Resumable Upload API and returns a url→handle map. The
+// handle is what Meta's message_templates endpoint requires under
+// `example.header_handle` — passing a raw URL there returns error
+// 100/2388215 ("Invalid parameter").
+//
+// We upload at Create time (synchronously) because Meta requires the handle
+// to exist *before* the template submission completes. Handles are cached
+// per-URL inside the call so a 10-card carousel that reuses the same image
+// twice only uploads it once.
+//
+// The flow is two HTTP calls per URL:
+//
+//  1. POST https://graph.facebook.com/{version}/{app_id}/uploads
+//     ?file_length=N&file_type=image/jpeg
+//     &access_token={app_id}|{app_secret}
+//     → {"id":"upload:..."}
+//
+//  2. POST https://graph.facebook.com/{version}/{upload_session_id}
+//     headers: Authorization: OAuth {user_access_token}, file_offset: 0
+//     body:    raw bytes
+//     → {"h":"4::aW1hZ2..."}
+//
+// metaAccessToken is the WABA's access token (system-user token), used for
+// the bytes-upload step. metaAppID + metaAppSecret form the app access token
+// used for the init step.
+func (s *whatsappRichTemplateService) uploadCarouselHeaderMedia(
+	ctx context.Context,
+	tpl *whatsapp.RichTemplate,
+	metaAccessToken string,
+) (map[string]string, error) {
+	// Walk the template and collect every URL that will need a handle.
+	type urlSpec struct {
+		url         string
+		contentType string
+	}
+	specs := make([]urlSpec, 0, len(tpl.Cards)+1)
+	seen := make(map[string]bool)
+	push := func(u, ct string) {
+		if u == "" || seen[u] {
+			return
+		}
+		seen[u] = true
+		specs = append(specs, urlSpec{url: u, contentType: ct})
+	}
+
+	if tpl.Header != nil {
+		push(tpl.Header.ImageURL, guessImageContentType(tpl.Header.ImageURL))
+		push(tpl.Header.VideoURL, guessVideoContentType(tpl.Header.VideoURL))
+		push(tpl.Header.DocumentURL, "application/pdf")
+	}
+	for _, c := range tpl.Cards {
+		push(c.HeaderImageURL, guessImageContentType(c.HeaderImageURL))
+		push(c.HeaderVideoURL, guessVideoContentType(c.HeaderVideoURL))
+	}
+
+	if len(specs) == 0 {
+		return nil, nil
+	}
+
+	if s.metaAppID == "" || s.metaAppSecret == "" {
+		return nil, fmt.Errorf("meta app credentials not configured: cannot upload media handles required by Meta's carousel template API. " +
+			"Set FREERANGE_PROVIDERS_META_WHATSAPP_META_APP_ID and FREERANGE_PROVIDERS_META_WHATSAPP_META_APP_SECRET in your env")
+	}
+
+	out := make(map[string]string, len(specs))
+	for _, sp := range specs {
+		handle, err := s.uploadOneMediaURL(ctx, sp.url, sp.contentType, metaAccessToken)
+		if err != nil {
+			return nil, fmt.Errorf("upload %s: %w", sp.url, err)
+		}
+		out[sp.url] = handle
+	}
+	return out, nil
+}
+
+// uploadOneMediaURL runs the two-step resumable upload for a single URL.
+// Returns the `h` handle that should be passed to message_templates as
+// example.header_handle[0].
+func (s *whatsappRichTemplateService) uploadOneMediaURL(
+	ctx context.Context,
+	srcURL, contentType, userAccessToken string,
+) (string, error) {
+	// Step A: fetch the bytes into memory. Media is bounded by Meta's
+	// per-asset limits (image ≤ 5 MB, video ≤ 16 MB, document ≤ 100 MB),
+	// so the simple in-memory approach is fine here.
+	getReq, err := http.NewRequestWithContext(ctx, http.MethodGet, srcURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("build get request: %w", err)
+	}
+	getResp, err := s.httpClient.Do(getReq)
+	if err != nil {
+		return "", fmt.Errorf("download media: %w", err)
+	}
+	defer getResp.Body.Close()
+	if getResp.StatusCode < 200 || getResp.StatusCode >= 300 {
+		return "", fmt.Errorf("download media returned status %d", getResp.StatusCode)
+	}
+	bodyBytes, err := io.ReadAll(getResp.Body)
+	if err != nil {
+		return "", fmt.Errorf("read media bytes: %w", err)
+	}
+	if ct := getResp.Header.Get("Content-Type"); ct != "" && contentType == "" {
+		contentType = ct
+	}
+	if contentType == "" {
+		contentType = "image/jpeg"
+	}
+
+	// Step B: initialise the upload session. The access_token here is the
+	// APP token (app_id|app_secret), NOT the user/WABA access token.
+	initURL := fmt.Sprintf(
+		"https://graph.facebook.com/%s/%s/uploads?file_length=%d&file_type=%s&access_token=%s%%7C%s",
+		s.apiVersion,
+		s.metaAppID,
+		len(bodyBytes),
+		contentType,
+		s.metaAppID,
+		s.metaAppSecret,
+	)
+	initReq, err := http.NewRequestWithContext(ctx, http.MethodPost, initURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("build init request: %w", err)
+	}
+	initResp, err := s.httpClient.Do(initReq)
+	if err != nil {
+		return "", fmt.Errorf("init upload session: %w", err)
+	}
+	defer initResp.Body.Close()
+	initBody, _ := io.ReadAll(initResp.Body)
+	if initResp.StatusCode < 200 || initResp.StatusCode >= 300 {
+		return "", parseMetaError(initResp.StatusCode, initBody)
+	}
+	var initParsed struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(initBody, &initParsed); err != nil {
+		return "", fmt.Errorf("decode init response: %w (body=%s)", err, string(initBody))
+	}
+	if initParsed.ID == "" {
+		return "", fmt.Errorf("init returned empty session id (body=%s)", string(initBody))
+	}
+
+	// Step C: upload the bytes. Authorization header here is the USER
+	// access token (OAuth scheme, not Bearer). file_offset starts at 0
+	// because we're doing the whole thing in one request.
+	uploadURL := fmt.Sprintf("https://graph.facebook.com/%s/%s", s.apiVersion, initParsed.ID)
+	upReq, err := http.NewRequestWithContext(ctx, http.MethodPost, uploadURL, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return "", fmt.Errorf("build upload request: %w", err)
+	}
+	upReq.Header.Set("Authorization", "OAuth "+userAccessToken)
+	upReq.Header.Set("file_offset", "0")
+	upReq.Header.Set("Content-Type", contentType)
+	upReq.ContentLength = int64(len(bodyBytes))
+
+	upResp, err := s.httpClient.Do(upReq)
+	if err != nil {
+		return "", fmt.Errorf("upload bytes: %w", err)
+	}
+	defer upResp.Body.Close()
+	upBody, _ := io.ReadAll(upResp.Body)
+	if upResp.StatusCode < 200 || upResp.StatusCode >= 300 {
+		return "", parseMetaError(upResp.StatusCode, upBody)
+	}
+	var upParsed struct {
+		H string `json:"h"`
+	}
+	if err := json.Unmarshal(upBody, &upParsed); err != nil {
+		return "", fmt.Errorf("decode upload response: %w (body=%s)", err, string(upBody))
+	}
+	if upParsed.H == "" {
+		return "", fmt.Errorf("upload returned empty handle (body=%s)", string(upBody))
+	}
+	return upParsed.H, nil
+}
+
+// applyMediaHandles returns a deep-ish copy of `tpl` with every header URL
+// rewritten to its uploaded handle. The original `tpl` is not mutated so
+// the caller can still persist the user-supplied URLs (handy for the UI to
+// re-render previews and to re-upload if a re-submission is needed).
+func applyMediaHandles(tpl *whatsapp.RichTemplate, handles map[string]string) *whatsapp.RichTemplate {
+	if len(handles) == 0 {
+		return tpl
+	}
+	clone := *tpl
+	if tpl.Header != nil {
+		hh := *tpl.Header
+		if h, ok := handles[hh.ImageURL]; ok {
+			hh.ImageURL = h
+		}
+		if h, ok := handles[hh.VideoURL]; ok {
+			hh.VideoURL = h
+		}
+		if h, ok := handles[hh.DocumentURL]; ok {
+			hh.DocumentURL = h
+		}
+		clone.Header = &hh
+	}
+	if len(tpl.Cards) > 0 {
+		clone.Cards = make([]whatsapp.CarouselCard, len(tpl.Cards))
+		for i, c := range tpl.Cards {
+			cc := c
+			if h, ok := handles[cc.HeaderImageURL]; ok {
+				cc.HeaderImageURL = h
+			}
+			if h, ok := handles[cc.HeaderVideoURL]; ok {
+				cc.HeaderVideoURL = h
+			}
+			clone.Cards[i] = cc
+		}
+	}
+	return &clone
+}
+
+// guessImageContentType makes a best-effort guess at the MIME type from the
+// URL extension. Meta's upload init endpoint requires a file_type, so we
+// pick a sensible default rather than failing.
+func guessImageContentType(u string) string {
+	switch lowerExt(u) {
+	case ".png":
+		return "image/png"
+	case ".webp":
+		return "image/webp"
+	case ".gif":
+		return "image/gif"
+	case ".jpg", ".jpeg":
+		return "image/jpeg"
+	}
+	return "image/jpeg"
+}
+
+func guessVideoContentType(u string) string {
+	switch lowerExt(u) {
+	case ".3gp":
+		return "video/3gpp"
+	case ".mov":
+		return "video/quicktime"
+	}
+	return "video/mp4"
+}
+
+// needsMediaHandles reports whether the template carries any header media
+// URL that Meta will require to be uploaded as a handle before submission.
+// Coupon-code and carousel kinds with image/video headers all qualify;
+// text-only templates do not.
+func needsMediaHandles(tpl *whatsapp.RichTemplate) bool {
+	if tpl == nil {
+		return false
+	}
+	if tpl.Header != nil {
+		if tpl.Header.ImageURL != "" || tpl.Header.VideoURL != "" || tpl.Header.DocumentURL != "" {
+			return true
+		}
+	}
+	for _, c := range tpl.Cards {
+		if c.HeaderImageURL != "" || c.HeaderVideoURL != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func lowerExt(u string) string {
+	if u == "" {
+		return ""
+	}
+	if i := strings.LastIndex(u, "?"); i >= 0 {
+		u = u[:i]
+	}
+	if i := strings.LastIndex(u, "#"); i >= 0 {
+		u = u[:i]
+	}
+	if i := strings.LastIndex(u, "."); i >= 0 {
+		return strings.ToLower(u[i:])
+	}
+	return ""
+}

--- a/internal/usecases/services/whatsapp_rich_template_service.go
+++ b/internal/usecases/services/whatsapp_rich_template_service.go
@@ -1,0 +1,925 @@
+package services
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/the-monkeys/freerangenotify/internal/domain/application"
+	"github.com/the-monkeys/freerangenotify/internal/domain/whatsapp"
+	"go.uber.org/zap"
+)
+
+// WhatsAppRichTemplateService is the authoring/management surface for the
+// rich-template store. Sits in front of the repository, the validator, and
+// the upstream provider authoring APIs (Meta Cloud API today; Twilio Content
+// API in Phase 2).
+type WhatsAppRichTemplateService interface {
+	Create(ctx context.Context, tpl *whatsapp.RichTemplate) (*whatsapp.RichTemplate, error)
+	Get(ctx context.Context, appID, id string) (*whatsapp.RichTemplate, error)
+	GetByName(ctx context.Context, appID, name string) (*whatsapp.RichTemplate, error)
+	List(ctx context.Context, filter whatsapp.RichTemplateFilter) ([]*whatsapp.RichTemplate, int64, error)
+	Delete(ctx context.Context, appID, id string) error
+	SyncApproval(ctx context.Context, appID, id string) (*whatsapp.RichTemplate, error)
+	Preview(ctx context.Context, appID, id string, variables map[string]string) (map[string]interface{}, error)
+	// ApplyMetaStatus is invoked by the Meta webhook handler when a
+	// message_template_status_update event fires. It locates the template by
+	// the Meta-side template_name + WABA ID and updates its MetaBinding.
+	ApplyMetaStatus(ctx context.Context, wabaID, templateName, status, reason string) error
+	// ApplyTwilioStatus is invoked by the Twilio content-status webhook
+	// handler. Locates the template by Twilio ContentSid and updates its
+	// TwilioBinding.
+	ApplyTwilioStatus(ctx context.Context, contentSid, status, reason string) error
+	// ResolveSendPayload turns an FRN-internal SendPayload (template_id +
+	// variables + per-card runtime data) into the wire-shape
+	// `whatsapp_rich` map the Meta provider expects at send-time. URL
+	// buttons with track_clicks=true are wrapped with the signed redirect
+	// URL so taps land on /v1/r/:sig and emit a clicked analytics event.
+	ResolveSendPayload(ctx context.Context, appID, notificationID string, payload whatsapp.SendPayload) (map[string]interface{}, error)
+	// ResolveTwilioSendPayload turns an FRN-internal SendPayload into the
+	// wire-shape the Twilio WhatsApp provider expects: a `content_sid` and
+	// a flat positional `content_variables` map. Carousel per-card overrides
+	// are emitted using Twilio's dotted-key convention (`<card+1>.<pos>`).
+	// Returns ErrTemplateNotConfigured when the template has no Twilio binding.
+	ResolveTwilioSendPayload(ctx context.Context, appID, notificationID string, payload whatsapp.SendPayload) (map[string]interface{}, error)
+	// EnableClickTracking wires the click-attribution signer + public URL
+	// after the service is constructed (since the signer is built later
+	// in container.go). Calling with signer==nil disables wrapping.
+	EnableClickTracking(signer *whatsapp.ClickSigner, publicURL string)
+}
+
+// httpDoer is the small subset of *http.Client we depend on so tests can
+// substitute an httptest.Server-backed client without ceremony.
+type httpDoer interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+type whatsappRichTemplateService struct {
+	repo          whatsapp.RichTemplateRepository
+	appRepo       application.Repository
+	httpClient    httpDoer
+	apiVersion    string
+	metaAppID     string // FRN's Facebook App ID, required for Resumable Upload init
+	metaAppSecret string // FRN's Facebook App Secret, required for Resumable Upload init
+	logger        *zap.Logger
+	now           func() time.Time
+	clickSigner   *whatsapp.ClickSigner // optional; nil disables click-attribution wrapping
+	publicURL     string                // base URL for /v1/r/{sig}; required when clickSigner is set
+}
+
+// EnableClickTracking sets the click-attribution signer + public URL. The
+// signer and URL are wired in container.go after both this service and the
+// signer are constructed; we keep the dependency optional so unit tests
+// can run without the signer.
+func (s *whatsappRichTemplateService) EnableClickTracking(signer *whatsapp.ClickSigner, publicURL string) {
+	s.clickSigner = signer
+	s.publicURL = publicURL
+}
+
+// NewWhatsAppRichTemplateService wires up the service. apiVersion defaults
+// to v23.0 when empty; tests typically inject httptest.Server.Client() and
+// can override `now` for deterministic CreatedAt assertions.
+func NewWhatsAppRichTemplateService(
+	repo whatsapp.RichTemplateRepository,
+	appRepo application.Repository,
+	httpClient httpDoer,
+	apiVersion string,
+	metaAppID, metaAppSecret string,
+	logger *zap.Logger,
+) WhatsAppRichTemplateService {
+	if apiVersion == "" {
+		apiVersion = "v23.0"
+	}
+	if httpClient == nil {
+		// Media upload requires bigger window than the default 15s; image
+		// downloads + Meta byte-upload can take several seconds on a slow
+		// link. 60s gives carousels with multiple media headers headroom.
+		httpClient = &http.Client{Timeout: 60 * time.Second}
+	}
+	return &whatsappRichTemplateService{
+		repo:          repo,
+		appRepo:       appRepo,
+		httpClient:    httpClient,
+		apiVersion:    apiVersion,
+		metaAppID:     metaAppID,
+		metaAppSecret: metaAppSecret,
+		logger:        logger,
+		now:           func() time.Time { return time.Now().UTC() },
+	}
+}
+
+// Create is the main authoring path: validate → stamp identity → submit to
+// every configured provider → persist with the resulting bindings.
+//
+// Per the plan §11 rollout matrix, Meta submission failures during Create
+// are returned as errors so the UI can show the user why their template was
+// rejected before the document is ever indexed. Twilio submission is
+// best-effort once Phase 2 ships — that part will move to a deferred path.
+func (s *whatsappRichTemplateService) Create(ctx context.Context, tpl *whatsapp.RichTemplate) (*whatsapp.RichTemplate, error) {
+	if tpl == nil {
+		return nil, fmt.Errorf("template is nil")
+	}
+	if errs := whatsapp.Validate(tpl); !errs.IsEmpty() {
+		return nil, errs
+	}
+	if tpl.AppID == "" {
+		return nil, fmt.Errorf("app_id is required")
+	}
+
+	// Reject duplicate (app_id, name) at this layer so the user sees a clear
+	// 409 instead of a confusing index conflict deeper in ES.
+	existing, err := s.repo.GetByName(ctx, tpl.AppID, tpl.Name)
+	if err != nil {
+		return nil, fmt.Errorf("lookup existing template: %w", err)
+	}
+	if existing != nil {
+		return nil, fmt.Errorf("rich template %q already exists for app %s", tpl.Name, tpl.AppID)
+	}
+
+	app, err := s.appRepo.GetByID(ctx, tpl.AppID)
+	if err != nil {
+		return nil, fmt.Errorf("load app %s: %w", tpl.AppID, err)
+	}
+	wa := app.Settings.WhatsApp
+	metaConfigured := wa != nil && wa.Provider == "meta" && wa.MetaAccessToken != "" && wa.MetaWABAID != ""
+	// Twilio Content API is submitted whenever Twilio creds are present on
+	// the app, regardless of the runtime Provider field — so an app can run
+	// Meta in prod and keep Twilio Content SIDs warm as a failover.
+	twilioConfigured := wa != nil && wa.AccountSID != "" && wa.AuthToken != ""
+
+	tpl.ID = "frn_tpl_" + uuid.NewString()
+	now := s.now()
+	tpl.CreatedAt = now
+	tpl.UpdatedAt = now
+	tpl.ApprovalState = whatsapp.ApprovalDraft
+	if tpl.Providers.Meta == nil {
+		tpl.Providers.Meta = &whatsapp.MetaBinding{}
+	}
+
+	// Lists are pure runtime interactive messages (no Meta template
+	// equivalent), so persist them as Draft without a submission round-trip.
+	// Products/MPM/Catalog are gated separately above by the validator.
+	skipMetaSubmission := tpl.Kind == whatsapp.KindList
+
+	if metaConfigured && !skipMetaSubmission {
+		// Meta carousel + media-header templates require an `header_handle`
+		// produced by the Resumable Upload API. Passing the raw URL returns
+		// error 100/2388215 ("Invalid parameter"). Upload first, then
+		// submit a payload copy with URLs swapped for handles.
+		submitTpl := tpl
+		if needsMediaHandles(tpl) {
+			handles, uErr := s.uploadCarouselHeaderMedia(ctx, tpl, wa.MetaAccessToken)
+			if uErr != nil {
+				return nil, fmt.Errorf("meta media upload failed: %w", uErr)
+			}
+			submitTpl = applyMediaHandles(tpl, handles)
+		}
+		metaBinding, err := s.submitToMeta(ctx, submitTpl, wa)
+		if err != nil {
+			return nil, fmt.Errorf("meta submission failed: %w", err)
+		}
+		tpl.Providers.Meta = metaBinding
+	} else if skipMetaSubmission {
+		// Runtime-only kinds don't need approval. Mark them approved so the
+		// UI surfaces them as ready-to-send.
+		tpl.ApprovalState = whatsapp.ApprovalApproved
+		s.logger.Info("Rich template created (runtime-only kind; no Meta submission)",
+			zap.String("kind", string(tpl.Kind)),
+			zap.String("name", tpl.Name))
+	} else {
+		// No Meta configured — keep ApprovalDraft so the user knows the
+		// template was stored but not yet shipped anywhere.
+		s.logger.Info("Rich template created without Meta submission (no Meta config on app)",
+			zap.String("app_id", tpl.AppID),
+			zap.String("name", tpl.Name))
+	}
+
+	// Best-effort Twilio submission: a failure here is logged but does not
+	// fail the whole Create. The Meta binding (when present) is the
+	// authoritative one for users running Meta as their active provider; the
+	// Twilio binding is a parity bonus.
+	if twilioConfigured && !skipMetaSubmission {
+		twBinding, err := s.submitToTwilio(ctx, tpl, wa)
+		if err != nil {
+			s.logger.Warn("Twilio Content API submission failed (template still persisted with Meta binding)",
+				zap.String("template", tpl.Name),
+				zap.Error(err))
+		} else {
+			tpl.Providers.Twilio = twBinding
+		}
+	}
+
+	tpl.ApprovalState = aggregateApprovalState(tpl.Providers)
+	if err := s.repo.Create(ctx, tpl); err != nil {
+		return nil, fmt.Errorf("persist template: %w", err)
+	}
+	return tpl, nil
+}
+
+// Get fetches a template by ID and enforces the app scope so cross-tenant
+// reads are rejected at the service boundary.
+func (s *whatsappRichTemplateService) Get(ctx context.Context, appID, id string) (*whatsapp.RichTemplate, error) {
+	tpl, err := s.repo.GetByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if tpl.AppID != appID {
+		return nil, fmt.Errorf("rich template %s does not belong to app %s", id, appID)
+	}
+	return tpl, nil
+}
+
+func (s *whatsappRichTemplateService) GetByName(ctx context.Context, appID, name string) (*whatsapp.RichTemplate, error) {
+	tpl, err := s.repo.GetByName(ctx, appID, name)
+	if err != nil {
+		return nil, err
+	}
+	if tpl == nil {
+		return nil, fmt.Errorf("rich template %q not found", name)
+	}
+	return tpl, nil
+}
+
+func (s *whatsappRichTemplateService) List(ctx context.Context, filter whatsapp.RichTemplateFilter) ([]*whatsapp.RichTemplate, int64, error) {
+	return s.repo.List(ctx, filter)
+}
+
+// Delete removes the FRN record but does not currently delete the upstream
+// Meta template — that requires confirming the user really wants the
+// approved template removed from their WABA, which the UI handles via a
+// separate confirmation flow. We log the orphan so it can be reconciled.
+func (s *whatsappRichTemplateService) Delete(ctx context.Context, appID, id string) error {
+	tpl, err := s.Get(ctx, appID, id)
+	if err != nil {
+		return err
+	}
+	if tpl.Providers.Meta != nil && tpl.Providers.Meta.TemplateName != "" {
+		s.logger.Warn("Deleting rich template; Meta template not removed from WABA",
+			zap.String("id", id),
+			zap.String("meta_template_name", tpl.Providers.Meta.TemplateName))
+	}
+	return s.repo.Delete(ctx, id)
+}
+
+// SyncApproval pulls the latest Meta template status from the Graph API and
+// updates the binding + aggregate ApprovalState. The polling path; the
+// webhook path is ApplyMetaStatus.
+func (s *whatsappRichTemplateService) SyncApproval(ctx context.Context, appID, id string) (*whatsapp.RichTemplate, error) {
+	tpl, err := s.Get(ctx, appID, id)
+	if err != nil {
+		return nil, err
+	}
+	if tpl.Providers.Meta == nil || tpl.Providers.Meta.TemplateName == "" {
+		return tpl, nil // never submitted; nothing to sync
+	}
+	app, err := s.appRepo.GetByID(ctx, appID)
+	if err != nil {
+		return nil, err
+	}
+	wa := app.Settings.WhatsApp
+	if wa == nil || wa.Provider != "meta" || wa.MetaAccessToken == "" || wa.MetaWABAID == "" {
+		return tpl, nil
+	}
+
+	status, reason, err := s.fetchMetaStatus(ctx, tpl.Providers.Meta.TemplateName, wa)
+	if err != nil {
+		return nil, err
+	}
+	tpl.Providers.Meta.Status = status
+	tpl.Providers.Meta.Reason = reason
+	tpl.Providers.Meta.UpdatedAt = s.now()
+	tpl.ApprovalState = aggregateApprovalState(tpl.Providers)
+	tpl.UpdatedAt = s.now()
+	if err := s.repo.Update(ctx, tpl); err != nil {
+		return nil, err
+	}
+	return tpl, nil
+}
+
+// Preview returns the Meta-side authoring JSON the service would submit for
+// a given template. Useful for UI side-by-side previews and debugging
+// without round-tripping to Graph API. Variable substitution is applied to
+// example values so the preview reflects what the recipient would see.
+func (s *whatsappRichTemplateService) Preview(ctx context.Context, appID, id string, variables map[string]string) (map[string]interface{}, error) {
+	tpl, err := s.Get(ctx, appID, id)
+	if err != nil {
+		return nil, err
+	}
+	payload := metaAuthoringPayload(tpl)
+	if len(variables) > 0 {
+		payload["_preview_variables"] = variables // surface for the UI side-by-side renderer
+	}
+	return payload, nil
+}
+
+// ApplyMetaStatus is invoked from the meta webhook handler so async approval
+// transitions land in the index without polling. Locates the template by
+// (WABA → app_id → name).
+func (s *whatsappRichTemplateService) ApplyMetaStatus(ctx context.Context, wabaID, templateName, status, reason string) error {
+	apps, err := s.appRepo.List(ctx, application.ApplicationFilter{Limit: 500})
+	if err != nil {
+		return err
+	}
+	var appID string
+	for _, app := range apps {
+		wa := app.Settings.WhatsApp
+		if wa != nil && wa.Provider == "meta" && wa.MetaWABAID == wabaID {
+			appID = app.AppID
+			break
+		}
+	}
+	if appID == "" {
+		s.logger.Warn("Template status webhook for unknown WABA",
+			zap.String("waba_id", wabaID),
+			zap.String("template_name", templateName))
+		return nil
+	}
+
+	// Find by Meta-side template_name (the name we submitted, which mirrors
+	// tpl.Name today but may diverge in future for collision avoidance).
+	tpl, err := s.repo.GetByName(ctx, appID, templateName)
+	if err != nil {
+		return err
+	}
+	if tpl == nil {
+		// Template was created outside FRN (raw Graph API) — nothing to do.
+		return nil
+	}
+	if tpl.Providers.Meta == nil {
+		tpl.Providers.Meta = &whatsapp.MetaBinding{TemplateName: templateName}
+	}
+	tpl.Providers.Meta.Status = strings.ToUpper(status)
+	tpl.Providers.Meta.Reason = reason
+	tpl.Providers.Meta.UpdatedAt = s.now()
+	tpl.ApprovalState = aggregateApprovalState(tpl.Providers)
+	tpl.UpdatedAt = s.now()
+	return s.repo.Update(ctx, tpl)
+}
+
+// ApplyTwilioStatus is the webhook-driven counterpart to ApplyMetaStatus.
+// Looks up by Twilio ContentSid (which we stored at submission time) and
+// updates the binding + aggregate state.
+func (s *whatsappRichTemplateService) ApplyTwilioStatus(ctx context.Context, contentSid, status, reason string) error {
+	// We don't have a "GetByTwilioSid" repo method, so do a small scan with
+	// a high cap. Twilio webhook volume is low (one per approval transition
+	// per template); the simpler implementation is fine here.
+	const scanCap = 1000
+	apps, err := s.appRepo.List(ctx, application.ApplicationFilter{Limit: 500})
+	if err != nil {
+		return err
+	}
+	for _, app := range apps {
+		tpls, _, err := s.repo.List(ctx, whatsapp.RichTemplateFilter{AppID: app.AppID, Limit: scanCap})
+		if err != nil {
+			s.logger.Warn("Twilio status webhook: list templates failed", zap.String("app_id", app.AppID), zap.Error(err))
+			continue
+		}
+		for _, tpl := range tpls {
+			if tpl.Providers.Twilio == nil || tpl.Providers.Twilio.ContentSid != contentSid {
+				continue
+			}
+			tpl.Providers.Twilio.Status = strings.ToLower(status)
+			tpl.Providers.Twilio.Reason = reason
+			tpl.Providers.Twilio.UpdatedAt = s.now()
+			tpl.ApprovalState = aggregateApprovalState(tpl.Providers)
+			tpl.UpdatedAt = s.now()
+			return s.repo.Update(ctx, tpl)
+		}
+	}
+	s.logger.Warn("Twilio status webhook for unknown ContentSid", zap.String("content_sid", contentSid))
+	return nil
+}
+
+// ResolveSendPayload loads the template referenced by SendPayload.TemplateID
+// and produces the wire-format `whatsapp_rich` map the Meta provider expects
+// at send-time. Per-button click-attribution wrapping happens here so the
+// provider stays purely a formatter.
+//
+// For carousel templates, per-card runtime data (header media overrides,
+// per-card variables, per-card button values) is interleaved into the wire
+// format. Missing per-card data falls back to the authored template values.
+func (s *whatsappRichTemplateService) ResolveSendPayload(ctx context.Context, appID, notificationID string, payload whatsapp.SendPayload) (map[string]interface{}, error) {
+	if payload.TemplateID == "" {
+		return nil, fmt.Errorf("send payload missing template_id")
+	}
+	tpl, err := s.Get(ctx, appID, payload.TemplateID)
+	if err != nil {
+		return nil, err
+	}
+	if tpl.Providers.Meta == nil || tpl.Providers.Meta.TemplateName == "" {
+		return nil, fmt.Errorf("template %s has no Meta binding (not submitted)", payload.TemplateID)
+	}
+
+	rich := map[string]interface{}{
+		"kind":          string(tpl.Kind),
+		"template_name": tpl.Providers.Meta.TemplateName,
+		"language":      tpl.Language,
+	}
+
+	// Top-level BODY variables in template order (1..n).
+	if vars := orderedVariableValues(tpl.Body, payload.Variables); len(vars) > 0 {
+		rich["body_variables"] = vars
+	}
+
+	switch tpl.Kind {
+	case whatsapp.KindCarousel:
+		rich["cards"] = s.resolveCarouselCards(tpl, payload, notificationID)
+	case whatsapp.KindCouponCode:
+		if tpl.CouponCode != "" {
+			rich["coupon_code"] = tpl.CouponCode
+		}
+	}
+	return rich, nil
+}
+
+// resolveCarouselCards merges authored cards with per-card runtime overrides
+// and produces the wire-format `cards` array. Each card's button values are
+// signed via the click signer when track_clicks=true.
+func (s *whatsappRichTemplateService) resolveCarouselCards(tpl *whatsapp.RichTemplate, payload whatsapp.SendPayload, notificationID string) []map[string]interface{} {
+	out := make([]map[string]interface{}, 0, len(tpl.Cards))
+	for i, card := range tpl.Cards {
+		var override whatsapp.SendPayloadCard
+		if i < len(payload.Cards) {
+			override = payload.Cards[i]
+		}
+		wireCard := map[string]interface{}{}
+		// Header media: runtime override > authored URL.
+		switch {
+		case override.HeaderImageURL != "":
+			wireCard["header_image_url"] = override.HeaderImageURL
+		case override.HeaderVideoURL != "":
+			wireCard["header_video_url"] = override.HeaderVideoURL
+		case card.HeaderImageURL != "":
+			wireCard["header_image_url"] = card.HeaderImageURL
+		case card.HeaderVideoURL != "":
+			wireCard["header_video_url"] = card.HeaderVideoURL
+		}
+		// Body variables: runtime override > template-default.
+		vars := orderedVariableValues(card.Body, override.Variables)
+		if len(vars) > 0 {
+			wireCard["body_variables"] = vars
+		}
+		// Buttons in order. URL buttons with track_clicks → signed redirect.
+		buttons := make([]map[string]interface{}, 0, len(card.Buttons))
+		for j, b := range card.Buttons {
+			value := ""
+			if j < len(override.ButtonValues) {
+				value = override.ButtonValues[j]
+			}
+			buttons = append(buttons, s.resolveButton(b, j, value, notificationID, tpl.AppID))
+		}
+		wireCard["buttons"] = buttons
+		out = append(out, wireCard)
+	}
+	return out
+}
+
+// resolveButton produces the wire-shape for one button. For URL buttons
+// with TrackClicks=true and a non-empty runtime value, the value is wrapped
+// in a signed redirect URL. The value supplied by the caller is treated as
+// the path tail substituted into the authored URL pattern.
+func (s *whatsappRichTemplateService) resolveButton(b whatsapp.Button, index int, runtimeValue, notificationID, appID string) map[string]interface{} {
+	out := map[string]interface{}{
+		"sub_type": string(b.Type),
+		"text":     runtimeValue,
+	}
+	switch b.Type {
+	case whatsapp.ButtonURL:
+		if b.TrackClicks && s.clickSigner != nil && s.publicURL != "" && runtimeValue != "" {
+			target := b.URL
+			// Substitute {{1}} (typical URL variable position) so the
+			// click event lands on the real destination.
+			if strings.Contains(target, "{{1}}") {
+				target = strings.ReplaceAll(target, "{{1}}", runtimeValue)
+			} else if !strings.HasSuffix(target, runtimeValue) {
+				// No variable position: append runtimeValue as a path suffix.
+				if !strings.HasSuffix(target, "/") {
+					target += "/"
+				}
+				target += runtimeValue
+			}
+			signed, err := s.clickSigner.Sign(whatsapp.ClickPayload{
+				NotificationID: notificationID,
+				AppID:          appID,
+				ButtonIndex:    index,
+				TargetURL:      target,
+			})
+			if err == nil {
+				// Pass the sig as the runtime value — the authored template
+				// URL must be `{public_url}/v1/r/{{1}}` for this to work.
+				out["text"] = signed
+				out["tracked_target"] = target // for analytics correlation
+			}
+		}
+	case whatsapp.ButtonQuickReply:
+		out["payload"] = b.Payload
+		delete(out, "text")
+	case whatsapp.ButtonCopyCode:
+		out["coupon_code"] = b.CouponCode
+		delete(out, "text")
+	}
+	return out
+}
+
+// orderedVariableValues returns the variable values in the order they
+// appear in `body`. Caller's `vars` map keys are stringified positional
+// indices ("1", "2", ...). Missing values stay empty so the receiver sees
+// the literal placeholder — that is preferable to a runtime error for the
+// common "user didn't supply var" case.
+func orderedVariableValues(body string, vars map[string]string) []string {
+	matches := varRE.FindAllStringSubmatch(body, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	max := 0
+	for _, m := range matches {
+		n := 0
+		for _, ch := range m[1] {
+			n = n*10 + int(ch-'0')
+		}
+		if n > max {
+			max = n
+		}
+	}
+	out := make([]string, max)
+	for i := 0; i < max; i++ {
+		out[i] = vars[fmt.Sprintf("%d", i+1)]
+	}
+	return out
+}
+
+// --- Twilio Content API ---
+
+// submitToTwilio submits the template to the Twilio Content API and then
+// requests WhatsApp approval. Returns the TwilioBinding populated with the
+// content_sid and approval_sid.
+func (s *whatsappRichTemplateService) submitToTwilio(ctx context.Context, tpl *whatsapp.RichTemplate, wa *application.WhatsAppAppConfig) (*whatsapp.TwilioBinding, error) {
+	payload := twilioContentPayload(tpl)
+	body, _ := json.Marshal(payload)
+
+	createReq, err := http.NewRequestWithContext(ctx, http.MethodPost, twilioContentBaseURL+"/Content", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	createReq.Header.Set("Content-Type", "application/json")
+	createReq.SetBasicAuth(wa.AccountSID, wa.AuthToken)
+
+	resp, err := s.httpClient.Do(createReq)
+	if err != nil {
+		return nil, fmt.Errorf("twilio create content: %w", err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("twilio create content returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+	var created struct {
+		SID string `json:"sid"`
+	}
+	if err := json.Unmarshal(respBody, &created); err != nil {
+		return nil, fmt.Errorf("decode twilio content create: %w", err)
+	}
+	if created.SID == "" {
+		return nil, fmt.Errorf("twilio create content returned no SID")
+	}
+
+	// Submit for WhatsApp approval. category is required and mirrors Meta.
+	approvalBody, _ := json.Marshal(map[string]interface{}{
+		"name":     tpl.Name,
+		"category": strings.ToLower(tpl.Category),
+	})
+	approvalReq, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		fmt.Sprintf("%s/Content/%s/ApprovalRequests/whatsapp", twilioContentBaseURL, created.SID),
+		bytes.NewReader(approvalBody))
+	if err != nil {
+		return nil, err
+	}
+	approvalReq.Header.Set("Content-Type", "application/json")
+	approvalReq.SetBasicAuth(wa.AccountSID, wa.AuthToken)
+	approvalResp, err := s.httpClient.Do(approvalReq)
+	if err != nil {
+		return nil, fmt.Errorf("twilio approval request: %w", err)
+	}
+	defer approvalResp.Body.Close()
+	approvalRespBody, _ := io.ReadAll(approvalResp.Body)
+	if approvalResp.StatusCode < 200 || approvalResp.StatusCode >= 300 {
+		// Approval request failed but content was created — still bind the
+		// SID so we can retry approval later via SyncApproval.
+		s.logger.Warn("Twilio approval request failed; content sid bound for retry",
+			zap.String("content_sid", created.SID),
+			zap.Int("status", approvalResp.StatusCode),
+			zap.String("body", string(approvalRespBody)))
+		now := s.now()
+		return &whatsapp.TwilioBinding{
+			ContentSid:  created.SID,
+			Status:      "unsubmitted",
+			Reason:      string(approvalRespBody),
+			SubmittedAt: now,
+			UpdatedAt:   now,
+		}, nil
+	}
+	var approval struct {
+		Status string `json:"status"`
+		SID    string `json:"sid"`
+	}
+	_ = json.Unmarshal(approvalRespBody, &approval)
+	now := s.now()
+	status := strings.ToLower(approval.Status)
+	if status == "" {
+		status = "pending"
+	}
+	return &whatsapp.TwilioBinding{
+		ContentSid:  created.SID,
+		ApprovalSid: approval.SID,
+		Status:      status,
+		SubmittedAt: now,
+		UpdatedAt:   now,
+	}, nil
+}
+
+// twilioContentBaseURL is exposed as a package variable so tests can
+// rewrite it to point at an httptest server. Default is Twilio's production
+// Content API endpoint.
+var twilioContentBaseURL = "https://content.twilio.com/v1"
+
+// --- Meta authoring API ---
+
+// submitToMeta translates the typed RichTemplate to Meta's
+// message_templates authoring JSON and POSTs it to Graph API. Returns the
+// populated MetaBinding (template ID, initial status).
+func (s *whatsappRichTemplateService) submitToMeta(ctx context.Context, tpl *whatsapp.RichTemplate, wa *application.WhatsAppAppConfig) (*whatsapp.MetaBinding, error) {
+	payload := metaAuthoringPayload(tpl)
+	body, _ := json.Marshal(payload)
+
+	url := fmt.Sprintf("https://graph.facebook.com/%s/%s/message_templates", s.apiVersion, wa.MetaWABAID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+wa.MetaAccessToken)
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("meta http request: %w", err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, parseMetaError(resp.StatusCode, respBody)
+	}
+
+	var parsed struct {
+		ID       string `json:"id"`
+		Status   string `json:"status"`
+		Category string `json:"category"`
+	}
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		return nil, fmt.Errorf("decode meta response: %w (body=%s)", err, string(respBody))
+	}
+
+	now := s.now()
+	return &whatsapp.MetaBinding{
+		TemplateName: tpl.Name,
+		TemplateID:   parsed.ID,
+		Status:       strings.ToUpper(parsed.Status),
+		SubmittedAt:  now,
+		UpdatedAt:    now,
+	}, nil
+}
+
+// fetchMetaStatus polls Graph API for the current status of an already-
+// submitted template. Used by SyncApproval.
+func (s *whatsappRichTemplateService) fetchMetaStatus(ctx context.Context, templateName string, wa *application.WhatsAppAppConfig) (string, string, error) {
+	url := fmt.Sprintf("https://graph.facebook.com/%s/%s/message_templates?name=%s&access_token=%s",
+		s.apiVersion, wa.MetaWABAID, templateName, wa.MetaAccessToken)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", "", err
+	}
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return "", "", err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", "", parseMetaError(resp.StatusCode, body)
+	}
+	var parsed struct {
+		Data []struct {
+			Status string `json:"status"`
+			Reason string `json:"rejection_reason"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return "", "", fmt.Errorf("decode meta status list: %w", err)
+	}
+	if len(parsed.Data) == 0 {
+		return "", "", fmt.Errorf("template %q not found on meta", templateName)
+	}
+	return strings.ToUpper(parsed.Data[0].Status), parsed.Data[0].Reason, nil
+}
+
+// parseMetaError pulls the structured error out of a Meta response so the
+// caller surfaces a useful message instead of "got 400".
+func parseMetaError(status int, body []byte) error {
+	var e struct {
+		Error struct {
+			Message   string `json:"message"`
+			Type      string `json:"type"`
+			Code      int    `json:"code"`
+			Subcode   int    `json:"error_subcode"`
+			FBTraceID string `json:"fbtrace_id"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &e); err != nil || e.Error.Message == "" {
+		return fmt.Errorf("meta api returned status %d: %s", status, string(body))
+	}
+	return fmt.Errorf("meta error %d/%d (%s): %s [trace %s]",
+		e.Error.Code, e.Error.Subcode, e.Error.Type, e.Error.Message, e.Error.FBTraceID)
+}
+
+// aggregateApprovalState rolls per-provider status into the public
+// ApprovalState. Approved-by-any wins; otherwise pending dominates; only
+// when both providers reject do we report Rejected; only when no provider
+// was even tried do we keep Draft.
+func aggregateApprovalState(p whatsapp.ProviderBindings) whatsapp.ApprovalState {
+	metaState := providerState(p.Meta)
+	twilioState := providerState(p.Twilio)
+
+	if metaState == approvedHint || twilioState == approvedHint {
+		return whatsapp.ApprovalApproved
+	}
+	if metaState == disabledHint || twilioState == disabledHint {
+		return whatsapp.ApprovalDisabled
+	}
+	if metaState == pendingHint || twilioState == pendingHint {
+		return whatsapp.ApprovalPending
+	}
+	if metaState == rejectedHint && twilioState == rejectedHint {
+		return whatsapp.ApprovalRejected
+	}
+	if metaState == rejectedHint && twilioState == unknownHint {
+		return whatsapp.ApprovalRejected
+	}
+	if metaState == unknownHint && twilioState == unknownHint {
+		return whatsapp.ApprovalDraft
+	}
+	return whatsapp.ApprovalPartiallySubmitted
+}
+
+type providerStateHint int
+
+const (
+	unknownHint providerStateHint = iota
+	pendingHint
+	approvedHint
+	rejectedHint
+	disabledHint
+)
+
+// providerState reduces the per-provider raw status (which is provider-
+// specific casing) to one of the hint constants the aggregator uses.
+func providerState(b interface{}) providerStateHint {
+	var status string
+	switch v := b.(type) {
+	case *whatsapp.MetaBinding:
+		if v == nil {
+			return unknownHint
+		}
+		status = strings.ToLower(v.Status)
+	case *whatsapp.TwilioBinding:
+		if v == nil {
+			return unknownHint
+		}
+		status = strings.ToLower(v.Status)
+	}
+	switch status {
+	case "approved":
+		return approvedHint
+	case "pending":
+		return pendingHint
+	case "rejected":
+		return rejectedHint
+	case "disabled":
+		return disabledHint
+	default:
+		return unknownHint
+	}
+}
+
+// ErrTemplateNotConfigured is returned when an operation requires a Meta
+// binding that does not exist yet (e.g. SyncApproval on a draft template).
+var ErrTemplateNotConfigured = errors.New("template is not configured for the requested provider")
+
+// ResolveTwilioSendPayload loads the template referenced by
+// SendPayload.TemplateID and produces the wire-format the Twilio WhatsApp
+// provider expects:
+//
+//	{
+//	  "content_sid": "HX...",
+//	  "content_variables": { "1": "Asha", "2": "...", "1.1": "Trendy Polo", ... }
+//	}
+//
+// `content_variables` is a flat positional map. Top-level body variables
+// occupy keys "1".."n" verbatim from payload.Variables. For carousel
+// templates, per-card overrides supplied in payload.Cards are emitted with
+// Twilio's dotted-key convention: card index i (1-based) + "." + position.
+//
+// Returns ErrTemplateNotConfigured when the template has no Twilio binding.
+func (s *whatsappRichTemplateService) ResolveTwilioSendPayload(ctx context.Context, appID, notificationID string, payload whatsapp.SendPayload) (map[string]interface{}, error) {
+	if payload.TemplateID == "" {
+		return nil, fmt.Errorf("send payload missing template_id")
+	}
+	tpl, err := s.Get(ctx, appID, payload.TemplateID)
+	if err != nil {
+		return nil, err
+	}
+	if tpl.Providers.Twilio == nil || tpl.Providers.Twilio.ContentSid == "" {
+		return nil, ErrTemplateNotConfigured
+	}
+
+	vars := map[string]string{}
+	for k, v := range payload.Variables {
+		vars[k] = v
+	}
+
+	// Carousel: per-card variables get dotted keys ("1.1", "1.2", "2.1", ...).
+	// The signed-redirect wrapping applies to URL buttons with TrackClicks,
+	// emitted as additional dotted positional values when the authored
+	// template uses {{n}} in a card button's URL.
+	if tpl.Kind == whatsapp.KindCarousel {
+		for i, card := range payload.Cards {
+			cardIdx := i + 1
+			for k, v := range card.Variables {
+				vars[fmt.Sprintf("%d.%s", cardIdx, k)] = v
+			}
+			// Per-card button values (in order) — Twilio carousels typically
+			// expose the URL suffix variable as the last positional slot of
+			// each card. Click-attribution wrapping uses the same signer as
+			// the Meta path so analytics are consistent across providers.
+			if i < len(tpl.Cards) {
+				authoredCard := tpl.Cards[i]
+				for j, b := range authoredCard.Buttons {
+					var runtimeValue string
+					if j < len(card.ButtonValues) {
+						runtimeValue = card.ButtonValues[j]
+					}
+					if runtimeValue == "" {
+						continue
+					}
+					if b.Type == whatsapp.ButtonURL && b.TrackClicks && s.clickSigner != nil && s.publicURL != "" {
+						target := b.URL
+						if strings.Contains(target, "{{1}}") {
+							target = strings.ReplaceAll(target, "{{1}}", runtimeValue)
+						} else if !strings.HasSuffix(target, runtimeValue) {
+							if !strings.HasSuffix(target, "/") {
+								target += "/"
+							}
+							target += runtimeValue
+						}
+						signed, sErr := s.clickSigner.Sign(whatsapp.ClickPayload{
+							NotificationID: notificationID,
+							AppID:          appID,
+							ButtonIndex:    j,
+							TargetURL:      target,
+						})
+						if sErr == nil {
+							runtimeValue = signed
+						}
+					}
+					// Position the button value after the card body variables.
+					// Authoring convention: card body uses {{1}}..{{m}}, then
+					// the button URL suffix uses {{m+1}}. We approximate by
+					// placing the value at position (len(card.Variables)+j+1).
+					pos := len(card.Variables) + j + 1
+					vars[fmt.Sprintf("%d.%d", cardIdx, pos)] = runtimeValue
+				}
+			}
+		}
+	}
+
+	out := map[string]interface{}{
+		"content_sid": tpl.Providers.Twilio.ContentSid,
+	}
+	if len(vars) > 0 {
+		// Twilio expects a JSON-encoded string for ContentVariables on the
+		// wire, but the provider accepts a map[string]interface{} and
+		// json-marshals it itself. Keep the typed shape here.
+		contentVars := make(map[string]interface{}, len(vars))
+		for k, v := range vars {
+			contentVars[k] = v
+		}
+		out["content_variables"] = contentVars
+	}
+	return out, nil
+}

--- a/internal/usecases/services/whatsapp_rich_template_service_test.go
+++ b/internal/usecases/services/whatsapp_rich_template_service_test.go
@@ -1,0 +1,656 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/the-monkeys/freerangenotify/internal/domain/application"
+	"github.com/the-monkeys/freerangenotify/internal/domain/whatsapp"
+	"go.uber.org/zap"
+)
+
+// memRichRepo is an in-memory RichTemplateRepository used by service tests.
+// Keeps assertions about persistence (was Create called? was Update called?)
+// in the same package, instead of wiring the real Elasticsearch backend.
+type memRichRepo struct {
+	mu    sync.Mutex
+	byID  map[string]*whatsapp.RichTemplate
+}
+
+func newMemRichRepo() *memRichRepo {
+	return &memRichRepo{byID: map[string]*whatsapp.RichTemplate{}}
+}
+
+func (r *memRichRepo) Create(_ context.Context, tpl *whatsapp.RichTemplate) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.byID[tpl.ID] = tpl
+	return nil
+}
+func (r *memRichRepo) GetByID(_ context.Context, id string) (*whatsapp.RichTemplate, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	tpl, ok := r.byID[id]
+	if !ok {
+		return nil, &notFoundError{id: id}
+	}
+	return tpl, nil
+}
+func (r *memRichRepo) GetByName(_ context.Context, appID, name string) (*whatsapp.RichTemplate, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, t := range r.byID {
+		if t.AppID == appID && t.Name == name {
+			return t, nil
+		}
+	}
+	return nil, nil
+}
+func (r *memRichRepo) List(_ context.Context, filter whatsapp.RichTemplateFilter) ([]*whatsapp.RichTemplate, int64, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]*whatsapp.RichTemplate, 0, len(r.byID))
+	for _, t := range r.byID {
+		if filter.AppID != "" && t.AppID != filter.AppID {
+			continue
+		}
+		out = append(out, t)
+	}
+	return out, int64(len(out)), nil
+}
+func (r *memRichRepo) Update(_ context.Context, tpl *whatsapp.RichTemplate) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.byID[tpl.ID] = tpl
+	return nil
+}
+func (r *memRichRepo) Delete(_ context.Context, id string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.byID, id)
+	return nil
+}
+
+type notFoundError struct{ id string }
+
+func (e *notFoundError) Error() string { return "not found: " + e.id }
+
+// richStubAppRepo returns a single Meta-configured app for service tests. Other
+// Repository methods are unused on the rich-template service hot paths.
+// Named "rich…" to avoid colliding with stubAppRepo in credit_service_legacy_test.go.
+type richStubAppRepo struct{ app *application.Application }
+
+func (r *richStubAppRepo) Create(context.Context, *application.Application) error { return nil }
+func (r *richStubAppRepo) GetByID(_ context.Context, id string) (*application.Application, error) {
+	if r.app != nil && r.app.AppID == id {
+		return r.app, nil
+	}
+	return nil, &notFoundError{id: id}
+}
+func (r *richStubAppRepo) GetByAPIKey(context.Context, string) (*application.Application, error) {
+	return nil, nil
+}
+func (r *richStubAppRepo) Update(context.Context, *application.Application) error { return nil }
+func (r *richStubAppRepo) List(context.Context, application.ApplicationFilter) ([]*application.Application, error) {
+	if r.app == nil {
+		return nil, nil
+	}
+	return []*application.Application{r.app}, nil
+}
+func (r *richStubAppRepo) Delete(context.Context, string) error                          { return nil }
+func (r *richStubAppRepo) RegenerateAPIKey(context.Context, string) (string, error)      { return "", nil }
+
+// newServiceWithMockMeta wires up the service with an httptest server that
+// captures the inbound POST body so each test can assert what JSON we sent
+// to Meta. metaResponse is returned verbatim from POST + GET.
+func newServiceWithMockMeta(t *testing.T, metaResponse string, metaStatus int) (
+	svc WhatsAppRichTemplateService,
+	repo *memRichRepo,
+	captured *capturedRequest,
+	cleanup func(),
+) {
+	t.Helper()
+	captured = &capturedRequest{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		captured.mu.Lock()
+		captured.requests = append(captured.requests, capturedReq{Method: r.Method, Path: r.URL.Path, Body: string(body), Auth: r.Header.Get("Authorization")})
+		captured.mu.Unlock()
+		// Pass-through stubs for the Resumable Upload pipeline so carousel
+		// fixtures don't need real media. Same shape as the production
+		// Meta endpoints return.
+		switch {
+		case strings.Contains(r.URL.Path, "/uploads"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"id":"upload:TEST_SESSION_123"}`))
+			return
+		case strings.Contains(r.URL.Path, "upload:"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"h":"4::test_handle_xyz"}`))
+			return
+		case r.Method == http.MethodGet:
+			w.Header().Set("Content-Type", "image/jpeg")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("FAKEIMAGEBYTES"))
+			return
+		}
+		w.WriteHeader(metaStatus)
+		_, _ = w.Write([]byte(metaResponse))
+	}))
+
+	// Wire a service that points its httpClient at the test server by
+	// rewriting all outbound URLs at the transport layer. Cleaner than
+	// templating graph.facebook.com inside the service.
+	transport := &rewriteTransport{base: http.DefaultTransport, target: srv.URL}
+	repo = newMemRichRepo()
+	appRepo := &richStubAppRepo{app: &application.Application{
+		AppID: "app-1",
+		Settings: application.Settings{
+			WhatsApp: &application.WhatsAppAppConfig{
+				Provider:          "meta",
+				MetaWABAID:        "WABA_X",
+				MetaAccessToken:   "token-xyz",
+				MetaPhoneNumberID: "PH_1",
+			},
+		},
+	}}
+	httpClient := &http.Client{Transport: transport, Timeout: 5 * time.Second}
+	svc = NewWhatsAppRichTemplateService(repo, appRepo, httpClient, "v23.0", "test-app-id", "test-app-secret", zap.NewNop())
+	return svc, repo, captured, srv.Close
+}
+
+// rewriteTransport sends any outbound request to target (the httptest server)
+// while preserving the path so the service code can keep its graph.facebook.com
+// URLs unchanged.
+type rewriteTransport struct {
+	base   http.RoundTripper
+	target string
+}
+
+func (t *rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Replace scheme+host with the test target, keep path/query.
+	u := *req.URL
+	u.Scheme = "http"
+	u.Host = strings.TrimPrefix(t.target, "http://")
+	req.URL = &u
+	return t.base.RoundTrip(req)
+}
+
+// newServiceWithMockProviders wires the service with TWO httptest servers:
+// one acting as Meta Graph API, one as Twilio Content API. Routing happens
+// at the transport layer by Host (graph.facebook.com vs content.twilio.com).
+// Used by Phase 2 tests that exercise the dual-provider Create path.
+func newServiceWithMockProviders(t *testing.T) (
+	svc WhatsAppRichTemplateService,
+	repo *memRichRepo,
+	metaCaptured, twilioCaptured *capturedRequest,
+	cleanup func(),
+) {
+	t.Helper()
+	metaCaptured = &capturedRequest{}
+	twilioCaptured = &capturedRequest{}
+
+	metaSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		metaCaptured.mu.Lock()
+		metaCaptured.requests = append(metaCaptured.requests, capturedReq{Method: r.Method, Path: r.URL.Path, Body: string(body), Auth: r.Header.Get("Authorization")})
+		metaCaptured.mu.Unlock()
+		switch {
+		// Resumable Upload step A — init session.
+		case strings.Contains(r.URL.Path, "/uploads"):
+			_, _ = w.Write([]byte(`{"id":"upload:TEST_SESSION_123"}`))
+		// Resumable Upload step B — upload bytes. The path begins with the
+		// session id returned above.
+		case strings.Contains(r.URL.Path, "upload:"):
+			_, _ = w.Write([]byte(`{"h":"4::test_handle_xyz"}`))
+		// Stand-in for the actual image bytes the service downloads
+		// before uploading. The body content is irrelevant for these
+		// tests; we only need a 200.
+		case r.Method == http.MethodGet:
+			w.Header().Set("Content-Type", "image/jpeg")
+			_, _ = w.Write([]byte("FAKEIMAGEBYTES"))
+		default:
+			_, _ = w.Write([]byte(`{"id":"meta-tpl-001","status":"PENDING"}`))
+		}
+	}))
+
+	twilioSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		twilioCaptured.mu.Lock()
+		twilioCaptured.requests = append(twilioCaptured.requests, capturedReq{Method: r.Method, Path: r.URL.Path, Body: string(body), Auth: r.Header.Get("Authorization")})
+		twilioCaptured.mu.Unlock()
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/Content"):
+			_, _ = w.Write([]byte(`{"sid":"HXcontent123","friendly_name":"x"}`))
+		case strings.Contains(r.URL.Path, "/ApprovalRequests/whatsapp"):
+			_, _ = w.Write([]byte(`{"sid":"HXapproval456","status":"pending"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+
+	// Route requests by Host: graph.facebook.com → metaSrv, content.twilio.com → twilioSrv.
+	transport := &hostRouterTransport{
+		metaTarget:   metaSrv.URL,
+		twilioTarget: twilioSrv.URL,
+		base:         http.DefaultTransport,
+	}
+
+	repo = newMemRichRepo()
+	appRepo := &richStubAppRepo{app: &application.Application{
+		AppID: "app-1",
+		Settings: application.Settings{
+			WhatsApp: &application.WhatsAppAppConfig{
+				Provider:          "meta",
+				MetaWABAID:        "WABA_X",
+				MetaAccessToken:   "token-xyz",
+				MetaPhoneNumberID: "PH_1",
+				// Twilio creds also present so dual-submission triggers.
+				AccountSID: "AC_test",
+				AuthToken:  "twauth",
+				FromNumber: "+1555",
+			},
+		},
+	}}
+	httpClient := &http.Client{Transport: transport, Timeout: 5 * time.Second}
+	svc = NewWhatsAppRichTemplateService(repo, appRepo, httpClient, "v23.0", "test-app-id", "test-app-secret", zap.NewNop())
+	return svc, repo, metaCaptured, twilioCaptured, func() {
+		metaSrv.Close()
+		twilioSrv.Close()
+	}
+}
+
+// hostRouterTransport routes outbound HTTP based on the request Host header
+// so a single *http.Client can talk to both the mocked Meta endpoint and
+// the mocked Twilio endpoint within one test.
+type hostRouterTransport struct {
+	metaTarget   string
+	twilioTarget string
+	base         http.RoundTripper
+}
+
+func (t *hostRouterTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	u := *req.URL
+	u.Scheme = "http"
+	switch {
+	case strings.Contains(req.URL.Host, "content.twilio.com"):
+		u.Host = strings.TrimPrefix(t.twilioTarget, "http://")
+	default:
+		// Everything else (graph.facebook.com plus any test cdn:// host
+		// the upload pre-fetch tries to download) goes to the meta mock.
+		u.Host = strings.TrimPrefix(t.metaTarget, "http://")
+	}
+	req.URL = &u
+	return t.base.RoundTrip(req)
+}
+
+type capturedReq struct {
+	Method string
+	Path   string
+	Body   string
+	Auth   string
+}
+
+type capturedRequest struct {
+	mu       sync.Mutex
+	requests []capturedReq
+}
+
+func (c *capturedRequest) all() []capturedReq {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]capturedReq, len(c.requests))
+	copy(out, c.requests)
+	return out
+}
+
+// TestCreate_CarouselSubmitsToMeta asserts that creating a carousel rich
+// template (a) submits the documented authoring JSON to Meta, (b) persists
+// the returned template_id under Providers.Meta, and (c) sets the aggregate
+// approval state to Pending while Meta reviews.
+func TestCreate_CarouselSubmitsToMeta(t *testing.T) {
+	resp := `{"id":"meta-tpl-001","status":"PENDING","category":"MARKETING"}`
+	svc, repo, captured, cleanup := newServiceWithMockMeta(t, resp, http.StatusOK)
+	defer cleanup()
+
+	tpl := &whatsapp.RichTemplate{
+		Name:     "snapdeal_styles",
+		AppID:    "app-1",
+		Language: "en_US",
+		Category: "MARKETING",
+		Kind:     whatsapp.KindCarousel,
+		Body:     "Hi {{1}}, check these out:",
+		Cards: []whatsapp.CarouselCard{
+			{
+				HeaderImageURL: "https://cdn/p1.jpg",
+				Body:           "Polo {{1}} {{2}}",
+				Buttons:        []whatsapp.Button{{Type: whatsapp.ButtonURL, Text: "View", URL: "https://shop/p/1"}},
+			},
+			{
+				HeaderImageURL: "https://cdn/p2.jpg",
+				Body:           "Tee {{1}}",
+				Buttons:        []whatsapp.Button{{Type: whatsapp.ButtonURL, Text: "View", URL: "https://shop/p/2"}},
+			},
+		},
+	}
+
+	got, err := svc.Create(context.Background(), tpl)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Identity stamped + persisted.
+	if got.ID == "" || !strings.HasPrefix(got.ID, "frn_tpl_") {
+		t.Errorf("expected frn_tpl_ prefixed id, got %q", got.ID)
+	}
+	if _, err := repo.GetByID(context.Background(), got.ID); err != nil {
+		t.Errorf("template not persisted: %v", err)
+	}
+	if got.Providers.Meta == nil || got.Providers.Meta.TemplateID != "meta-tpl-001" {
+		t.Errorf("MetaBinding not populated: %+v", got.Providers.Meta)
+	}
+	if got.ApprovalState != whatsapp.ApprovalPending {
+		t.Errorf("ApprovalState: got %q, want pending", got.ApprovalState)
+	}
+
+	// Wire-shape: the create flow now also performs Resumable Upload for
+	// each distinct carousel header image (Meta requires handles, not
+	// raw URLs). Expected pipeline per card: GET image bytes, POST /uploads
+	// to init session, POST upload:... to send bytes, then ONE POST
+	// /message_templates carrying the resulting handles.
+	reqs := captured.all()
+	if len(reqs) < 2 {
+		t.Fatalf("expected at least 2 outbound requests (upload + submit), got %d", len(reqs))
+	}
+	// Find the template submission — it's the only POST hitting
+	// /message_templates.
+	var submitReq *capturedReq
+	for i := range reqs {
+		if strings.HasSuffix(reqs[i].Path, "/WABA_X/message_templates") {
+			submitReq = &reqs[i]
+			break
+		}
+	}
+	if submitReq == nil {
+		t.Fatalf("no template submission found among requests: %+v", reqs)
+	}
+	if submitReq.Method != "POST" {
+		t.Errorf("expected POST, got %s", submitReq.Method)
+	}
+	if submitReq.Auth != "Bearer token-xyz" {
+		t.Errorf("auth header: got %q", submitReq.Auth)
+	}
+	// Spot-check the JSON: carousel + per-card body example present, and
+	// the header_handle should now contain the uploaded handle, NOT the
+	// raw cdn URL.
+	for _, needle := range []string{
+		`"type":"CAROUSEL"`,
+		`"category":"MARKETING"`,
+		`"language":"en_US"`,
+		`"header_handle":["4::test_handle_xyz"]`, // upload handle, not raw URL
+		`"body_text":[["sample","sample"]]`,      // 2 vars in card 0 body
+	} {
+		if !strings.Contains(submitReq.Body, needle) {
+			t.Errorf("Meta payload missing %q\nbody=%s", needle, submitReq.Body)
+		}
+	}
+	// The raw cdn URL must NOT appear in the submission body — that was
+	// the exact bug that caused error 100/2388215 in production.
+	if strings.Contains(submitReq.Body, "https://cdn/p1.jpg") {
+		t.Errorf("submission body still contains raw cdn URL; upload swap did not run\nbody=%s", submitReq.Body)
+	}
+}
+
+// TestCreate_ValidationFailsBeforeSubmit asserts that invalid templates are
+// rejected by the validator with no Meta round-trip.
+func TestCreate_ValidationFailsBeforeSubmit(t *testing.T) {
+	svc, _, captured, cleanup := newServiceWithMockMeta(t, `{}`, http.StatusOK)
+	defer cleanup()
+
+	// Carousel with only 1 card violates CAROUSEL_CARD_COUNT.
+	tpl := &whatsapp.RichTemplate{
+		Name: "bad", AppID: "app-1", Language: "en_US", Category: "MARKETING", Kind: whatsapp.KindCarousel,
+		Cards: []whatsapp.CarouselCard{{HeaderImageURL: "https://x", Body: "x", Buttons: []whatsapp.Button{{Type: whatsapp.ButtonURL, Text: "x", URL: "https://x"}}}},
+	}
+	_, err := svc.Create(context.Background(), tpl)
+	if err == nil {
+		t.Fatalf("expected validation error, got nil")
+	}
+	if len(captured.all()) != 0 {
+		t.Errorf("validator failed to short-circuit; Meta was called")
+	}
+}
+
+// TestCreate_RejectsDuplicateName ensures (app_id, name) uniqueness is
+// enforced at the service boundary so the UI gets a clear conflict.
+func TestCreate_RejectsDuplicateName(t *testing.T) {
+	svc, _, _, cleanup := newServiceWithMockMeta(t, `{"id":"x","status":"PENDING"}`, http.StatusOK)
+	defer cleanup()
+
+	tpl := func() *whatsapp.RichTemplate {
+		return &whatsapp.RichTemplate{
+			Name: "duplicate", AppID: "app-1", Language: "en_US", Category: "UTILITY",
+			Kind: whatsapp.KindCTAURL, Body: "x",
+			Buttons: []whatsapp.Button{{Type: whatsapp.ButtonURL, Text: "Go", URL: "https://x"}},
+		}
+	}
+
+	if _, err := svc.Create(context.Background(), tpl()); err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+	_, err := svc.Create(context.Background(), tpl())
+	if err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("expected duplicate-name error, got %v", err)
+	}
+}
+
+// TestApplyMetaStatus_UpdatesBindingAndAggregate verifies the webhook path:
+// a status update mutates the per-provider status and recomputes the
+// aggregate ApprovalState.
+func TestApplyMetaStatus_UpdatesBindingAndAggregate(t *testing.T) {
+	svc, repo, _, cleanup := newServiceWithMockMeta(t, `{"id":"meta-x","status":"PENDING"}`, http.StatusOK)
+	defer cleanup()
+
+	tpl, err := svc.Create(context.Background(), &whatsapp.RichTemplate{
+		Name: "promo", AppID: "app-1", Language: "en_US", Category: "MARKETING",
+		Kind: whatsapp.KindCTAURL, Body: "tap",
+		Buttons: []whatsapp.Button{{Type: whatsapp.ButtonURL, Text: "Go", URL: "https://x"}},
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if tpl.ApprovalState != whatsapp.ApprovalPending {
+		t.Fatalf("expected pending after create, got %s", tpl.ApprovalState)
+	}
+
+	if err := svc.ApplyMetaStatus(context.Background(), "WABA_X", "promo", "APPROVED", ""); err != nil {
+		t.Fatalf("ApplyMetaStatus: %v", err)
+	}
+	got, _ := repo.GetByID(context.Background(), tpl.ID)
+	if got.Providers.Meta.Status != "APPROVED" {
+		t.Errorf("Meta status: got %q", got.Providers.Meta.Status)
+	}
+	if got.ApprovalState != whatsapp.ApprovalApproved {
+		t.Errorf("aggregate: got %q, want approved", got.ApprovalState)
+	}
+}
+
+// TestCreate_AlsoSubmitsToTwilio asserts that when an app has BOTH Meta
+// and Twilio credentials, Create submits to both providers and persists
+// both bindings. Twilio submission is best-effort: the test wires the
+// happy path here; the warn-on-failure path is exercised separately.
+func TestCreate_AlsoSubmitsToTwilio(t *testing.T) {
+	svc, _, metaCap, twilioCap, cleanup := newServiceWithMockProviders(t)
+	defer cleanup()
+
+	tpl, err := svc.Create(context.Background(), &whatsapp.RichTemplate{
+		Name: "dual_promo", AppID: "app-1", Language: "en_US", Category: "MARKETING",
+		Kind: whatsapp.KindCTAURL, Body: "Tap below",
+		Buttons: []whatsapp.Button{{Type: whatsapp.ButtonURL, Text: "Visit", URL: "https://x"}},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if tpl.Providers.Meta == nil || tpl.Providers.Meta.TemplateID != "meta-tpl-001" {
+		t.Errorf("Meta binding missing: %+v", tpl.Providers.Meta)
+	}
+	if tpl.Providers.Twilio == nil || tpl.Providers.Twilio.ContentSid != "HXcontent123" {
+		t.Errorf("Twilio binding missing: %+v", tpl.Providers.Twilio)
+	}
+	if tpl.Providers.Twilio.ApprovalSid != "HXapproval456" {
+		t.Errorf("Twilio approval_sid missing: %+v", tpl.Providers.Twilio)
+	}
+	if len(metaCap.all()) != 1 {
+		t.Errorf("expected 1 Meta call, got %d", len(metaCap.all()))
+	}
+	if len(twilioCap.all()) != 2 {
+		t.Errorf("expected 2 Twilio calls (create+approval), got %d", len(twilioCap.all()))
+	}
+	createCall := twilioCap.all()[0]
+	for _, needle := range []string{`"twilio/call-to-action"`, `"body":"Tap below"`, `"url":"https://x"`} {
+		if !strings.Contains(createCall.Body, needle) {
+			t.Errorf("Twilio body missing %q\nbody=%s", needle, createCall.Body)
+		}
+	}
+}
+
+// TestApplyTwilioStatus_UpdatesBindingAndAggregate verifies the Twilio
+// webhook path: receiving an "approved" status flips the aggregate from
+// pending to approved.
+func TestApplyTwilioStatus_UpdatesBindingAndAggregate(t *testing.T) {
+	svc, repo, _, _, cleanup := newServiceWithMockProviders(t)
+	defer cleanup()
+
+	tpl, err := svc.Create(context.Background(), &whatsapp.RichTemplate{
+		Name: "twilio_promo", AppID: "app-1", Language: "en_US", Category: "MARKETING",
+		Kind: whatsapp.KindCTAURL, Body: "x",
+		Buttons: []whatsapp.Button{{Type: whatsapp.ButtonURL, Text: "Go", URL: "https://x"}},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if err := svc.ApplyTwilioStatus(context.Background(), "HXcontent123", "approved", ""); err != nil {
+		t.Fatalf("ApplyTwilioStatus: %v", err)
+	}
+	got, _ := repo.GetByID(context.Background(), tpl.ID)
+	if got.Providers.Twilio.Status != "approved" {
+		t.Errorf("Twilio status: got %q", got.Providers.Twilio.Status)
+	}
+	if got.ApprovalState != whatsapp.ApprovalApproved {
+		t.Errorf("aggregate: got %q, want approved", got.ApprovalState)
+	}
+}
+
+// TestResolveSendPayload_CarouselSignsTrackedURLs proves that a carousel
+// template with track_clicks=true buttons produces signed redirect values
+// at runtime — i.e., the worker can pass the resolved payload straight to
+// the Meta provider.
+func TestResolveSendPayload_CarouselSignsTrackedURLs(t *testing.T) {
+	svc, _, _, _, cleanup := newServiceWithMockProviders(t)
+	defer cleanup()
+
+	signer, err := whatsapp.NewClickSigner("test-key")
+	if err != nil {
+		t.Fatalf("NewClickSigner: %v", err)
+	}
+	svc.EnableClickTracking(signer, "https://api.test")
+
+	tpl, err := svc.Create(context.Background(), &whatsapp.RichTemplate{
+		Name: "tracked_carousel", AppID: "app-1", Language: "en_US", Category: "MARKETING",
+		Kind: whatsapp.KindCarousel,
+		Body: "Hi {{1}}",
+		Cards: []whatsapp.CarouselCard{
+			{HeaderImageURL: "https://cdn/1.jpg", Body: "Polo {{1}}",
+				Buttons: []whatsapp.Button{{Type: whatsapp.ButtonURL, Text: "View", URL: "https://shop/p/{{1}}", Example: "sku-1", TrackClicks: true}}},
+			{HeaderImageURL: "https://cdn/2.jpg", Body: "Tee {{1}}",
+				Buttons: []whatsapp.Button{{Type: whatsapp.ButtonURL, Text: "View", URL: "https://shop/p/{{1}}", Example: "sku-2", TrackClicks: true}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	resolved, err := svc.ResolveSendPayload(context.Background(), "app-1", "notif-7", whatsapp.SendPayload{
+		TemplateID: tpl.ID,
+		Variables:  map[string]string{"1": "Asha"},
+		Cards: []whatsapp.SendPayloadCard{
+			{Variables: map[string]string{"1": "Polo Trendy"}, ButtonValues: []string{"sku-1"}},
+			{Variables: map[string]string{"1": "Tee Cool"}, ButtonValues: []string{"sku-2"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ResolveSendPayload: %v", err)
+	}
+
+	// Sanity-check the shape.
+	if resolved["template_name"] != tpl.Providers.Meta.TemplateName {
+		t.Errorf("template_name mismatch: %v", resolved["template_name"])
+	}
+	cards, ok := resolved["cards"].([]map[string]interface{})
+	if !ok || len(cards) != 2 {
+		t.Fatalf("expected 2 cards, got %v", resolved["cards"])
+	}
+	for i, c := range cards {
+		buttons, _ := c["buttons"].([]map[string]interface{})
+		if len(buttons) != 1 {
+			t.Fatalf("card %d: expected 1 button, got %v", i, buttons)
+		}
+		text, _ := buttons[0]["text"].(string)
+		// Signed values contain a `.` separating payload and HMAC.
+		if !strings.Contains(text, ".") {
+			t.Errorf("card %d button text is not signed: %q", i, text)
+		}
+		// Verify the signature is valid by round-tripping through the signer.
+		payload, err := signer.Verify(text)
+		if err != nil {
+			t.Errorf("card %d signed value did not verify: %v", i, err)
+			continue
+		}
+		if payload.NotificationID != "notif-7" || payload.AppID != "app-1" {
+			t.Errorf("card %d payload identity: %+v", i, payload)
+		}
+		expectedTarget := "https://shop/p/sku-" + string(rune('1'+i))
+		if payload.TargetURL != expectedTarget {
+			t.Errorf("card %d target_url: got %q want %q", i, payload.TargetURL, expectedTarget)
+		}
+	}
+}
+
+// TestPreview_ReturnsAuthoringJSON sanity-checks the preview path so the UI
+// can render a side-by-side without hitting Meta.
+func TestPreview_ReturnsAuthoringJSON(t *testing.T) {
+	svc, _, _, cleanup := newServiceWithMockMeta(t, `{"id":"x","status":"PENDING"}`, http.StatusOK)
+	defer cleanup()
+
+	tpl, err := svc.Create(context.Background(), &whatsapp.RichTemplate{
+		Name: "coupon_drop", AppID: "app-1", Language: "en_US", Category: "MARKETING",
+		Kind: whatsapp.KindCouponCode, Body: "Use code {{1}}", CouponCode: "DEAL50",
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	preview, err := svc.Preview(context.Background(), "app-1", tpl.ID, map[string]string{"1": "DEAL50"})
+	if err != nil {
+		t.Fatalf("preview: %v", err)
+	}
+	b, _ := json.Marshal(preview)
+	wire := string(b)
+	for _, needle := range []string{
+		`"name":"coupon_drop"`,
+		`"category":"MARKETING"`,
+		`"type":"BUTTONS"`,
+		`"_preview_variables"`,
+	} {
+		if !strings.Contains(wire, needle) {
+			t.Errorf("preview missing %q\npreview=%s", needle, wire)
+		}
+	}
+}

--- a/internal/usecases/services/whatsapp_rich_twilio_payload.go
+++ b/internal/usecases/services/whatsapp_rich_twilio_payload.go
@@ -1,0 +1,184 @@
+package services
+
+import (
+	"strings"
+
+	"github.com/the-monkeys/freerangenotify/internal/domain/whatsapp"
+)
+
+// twilioContentPayload converts an FRN RichTemplate into the Twilio
+// Content API authoring shape. Twilio uses `{{n}}` placeholders verbatim
+// in body strings and exposes example values via the top-level `variables`
+// map (string keys, indexed from 1). The provider-specific component
+// shapes live under types.{twilio/carousel|twilio/call-to-action|...}.
+//
+// Twilio is deliberately permissive: unknown variables are echoed, missing
+// values render as the literal placeholder. We supply placeholder examples
+// matching the count of positional variables so approval reviewers see a
+// realistic preview.
+func twilioContentPayload(t *whatsapp.RichTemplate) map[string]interface{} {
+	out := map[string]interface{}{
+		"friendly_name": t.Name,
+		"language":      twilioLanguage(t.Language),
+	}
+
+	// Twilio expects positional variables as a flat map even when only the
+	// body references them — the SDK auto-prunes unused keys.
+	variables := map[string]string{}
+	for i, v := range exampleVarMatrix(t.Body) {
+		variables[positionalKey(i+1)] = v
+	}
+	if len(variables) > 0 {
+		out["variables"] = variables
+	}
+
+	switch t.Kind {
+	case whatsapp.KindCarousel:
+		out["types"] = map[string]interface{}{
+			"twilio/carousel": twilioCarouselType(t),
+		}
+	case whatsapp.KindCouponCode:
+		// Twilio represents coupon codes as a quick-reply with a single
+		// COPY_CODE-style action. The closest first-class type today is
+		// twilio/call-to-action with body + a single text action; FRN
+		// emits this minimally so the binding round-trips. UI may evolve
+		// to use Twilio's coupon component once GA.
+		out["types"] = map[string]interface{}{
+			"twilio/call-to-action": map[string]interface{}{
+				"body": t.Body,
+				"actions": []map[string]interface{}{
+					{"type": "QUICK_REPLY", "title": "Copy " + t.CouponCode, "id": "copy_code"},
+				},
+			},
+		}
+	case whatsapp.KindCTAURL:
+		out["types"] = map[string]interface{}{
+			"twilio/call-to-action": map[string]interface{}{
+				"body":    t.Body,
+				"actions": twilioActionsFromButtons(t.Buttons),
+			},
+		}
+	case whatsapp.KindQuickReply:
+		out["types"] = map[string]interface{}{
+			"twilio/quick-reply": map[string]interface{}{
+				"body":    t.Body,
+				"actions": twilioActionsFromButtons(t.Buttons),
+			},
+		}
+	case whatsapp.KindList:
+		items := []map[string]interface{}{}
+		for _, sec := range t.ListSections {
+			for _, r := range sec.Rows {
+				items = append(items, map[string]interface{}{
+					"item":        r.Title,
+					"id":          r.ID,
+					"description": r.Description,
+				})
+			}
+		}
+		out["types"] = map[string]interface{}{
+			"twilio/list-picker": map[string]interface{}{
+				"body":   t.Body,
+				"button": firstNonEmpty(t.ListButtonText, "Menu"),
+				"items":  items,
+			},
+		}
+	}
+	return out
+}
+
+// twilioCarouselType emits the twilio/carousel type body with one card per
+// authored CarouselCard. Twilio's per-card schema:
+//
+//	{
+//	  "title": "Polo {{1}} {{2}}",
+//	  "media": ["https://cdn/.../1.jpg"],
+//	  "actions": [{"type":"URL","title":"View","url":"https://shop/p/1"}]
+//	}
+//
+// Twilio doesn't separate header from body the way Meta does — the card
+// "title" carries the body text and the optional "media" array provides
+// the header image/video URL.
+func twilioCarouselType(t *whatsapp.RichTemplate) map[string]interface{} {
+	cards := make([]map[string]interface{}, 0, len(t.Cards))
+	for _, c := range t.Cards {
+		card := map[string]interface{}{"title": c.Body}
+		switch {
+		case c.HeaderImageURL != "":
+			card["media"] = []string{c.HeaderImageURL}
+		case c.HeaderVideoURL != "":
+			card["media"] = []string{c.HeaderVideoURL}
+		}
+		card["actions"] = twilioActionsFromButtons(c.Buttons)
+		cards = append(cards, card)
+	}
+	return map[string]interface{}{
+		"body":  t.Body,
+		"cards": cards,
+	}
+}
+
+// twilioActionsFromButtons converts FRN Button slice to Twilio's action
+// schema. Twilio uses uppercase action types matching Meta's button
+// taxonomy except for COPY_CODE (no first-class equivalent yet).
+func twilioActionsFromButtons(buttons []whatsapp.Button) []map[string]interface{} {
+	out := make([]map[string]interface{}, 0, len(buttons))
+	for _, b := range buttons {
+		a := map[string]interface{}{
+			"type":  string(b.Type),
+			"title": b.Text,
+		}
+		switch b.Type {
+		case whatsapp.ButtonURL:
+			a["url"] = b.URL
+		case whatsapp.ButtonPhone:
+			a["phone"] = b.PhoneNumber
+		case whatsapp.ButtonQuickReply:
+			if b.Payload != "" {
+				a["id"] = b.Payload
+			}
+		case whatsapp.ButtonCopyCode:
+			// Twilio doesn't yet expose a first-class COPY_CODE action;
+			// degrade to QUICK_REPLY with the code surfaced in the title.
+			a["type"] = "QUICK_REPLY"
+			a["id"] = "copy_code"
+			a["title"] = "Copy " + b.CouponCode
+		}
+		out = append(out, a)
+	}
+	return out
+}
+
+// twilioLanguage maps Meta-style `en_US` to Twilio-style `en`. Twilio
+// accepts the underscore form for some templates but the base code is
+// safer and consistent with their docs' examples.
+func twilioLanguage(meta string) string {
+	if idx := strings.Index(meta, "_"); idx > 0 {
+		return strings.ToLower(meta[:idx])
+	}
+	return strings.ToLower(meta)
+}
+
+// positionalKey formats a 1-based integer as the string key Twilio uses
+// for its variables map.
+func positionalKey(n int) string {
+	digits := ""
+	for n > 0 {
+		digits = string(rune('0'+n%10)) + digits
+		n /= 10
+	}
+	if digits == "" {
+		return "0"
+	}
+	return digits
+}
+
+// firstNonEmpty returns the first non-empty string from its arguments.
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/internal/usecases/services/whatsapp_service_impl.go
+++ b/internal/usecases/services/whatsapp_service_impl.go
@@ -201,6 +201,44 @@ func (s *whatsappService) publishSSE(eventType string, data map[string]interface
 	})
 }
 
+// classifyInboundEvent returns the high-level event name corresponding to
+// an InboundMessage. Used to populate `event_name` in the workflow trigger
+// payload so authors can branch on a single field rather than reverse-
+// engineering message_type / interactive_type combinations.
+//
+// Event names align with the WhatsApp dev doc taxonomy:
+//
+//	whatsapp.text                — free-form text reply
+//	whatsapp.media               — image / video / audio / document upload
+//	whatsapp.location            — location share
+//	whatsapp.button_clicked      — template URL/QR button tap
+//	whatsapp.list_reply          — list-picker selection
+//	whatsapp.quick_reply_clicked — interactive button reply
+//	whatsapp.reaction            — emoji reaction on a prior outbound message
+func classifyInboundEvent(msg *whatsapp.InboundMessage) string {
+	if msg.ReactionEmoji != "" {
+		return "whatsapp.reaction"
+	}
+	switch msg.InteractiveType {
+	case "button_reply":
+		return "whatsapp.quick_reply_clicked"
+	case "list_reply":
+		return "whatsapp.list_reply"
+	}
+	if msg.ButtonPayload != "" {
+		return "whatsapp.button_clicked"
+	}
+	switch msg.MessageType {
+	case "image", "video", "audio", "document", "sticker":
+		return "whatsapp.media"
+	case "location":
+		return "whatsapp.location"
+	case "text":
+		return "whatsapp.text"
+	}
+	return ""
+}
+
 func (s *whatsappService) triggerWorkflow(ctx context.Context, appID, triggerID string, msg *whatsapp.InboundMessage) {
 	if s.workflowSvc == nil || triggerID == "" {
 		return
@@ -215,6 +253,35 @@ func (s *whatsappService) triggerWorkflow(ctx context.Context, appID, triggerID 
 		"message_type":    msg.MessageType,
 		"text_body":       msg.TextBody,
 		"meta_message_id": msg.MetaMessageID,
+	}
+	// Phase 6 of WHATSAPP_RICH_INTERACTIVE_PLAN.md — surface parsed
+	// interactive / template-button click data so workflows can branch on
+	// `payload.button_payload == "REORDER"` / `payload.reply_id` / etc.
+	// without re-parsing raw_payload.
+	if msg.InteractiveType != "" {
+		payload["interactive_type"] = msg.InteractiveType
+	}
+	if msg.ReplyID != "" {
+		payload["reply_id"] = msg.ReplyID
+	}
+	if msg.ReplyTitle != "" {
+		payload["reply_title"] = msg.ReplyTitle
+	}
+	if msg.ReplyDescription != "" {
+		payload["reply_description"] = msg.ReplyDescription
+	}
+	if msg.ButtonPayload != "" {
+		payload["button_payload"] = msg.ButtonPayload
+	}
+	if msg.ReactionEmoji != "" {
+		payload["reaction_emoji"] = msg.ReactionEmoji
+	}
+	// Synthesise a higher-level event name workflows can match on. Letting
+	// workflow conditions filter by `event_name == "button_clicked"` is
+	// dramatically simpler than asking authors to "check if interactive_type
+	// is button_reply or button is set".
+	if eventName := classifyInboundEvent(msg); eventName != "" {
+		payload["event_name"] = eventName
 	}
 	_, err := s.workflowSvc.Trigger(ctx, appID, &workflow.TriggerRequest{
 		TriggerID: triggerID,

--- a/ui/src/components/whatsapp/WhatsAppConnect.tsx
+++ b/ui/src/components/whatsapp/WhatsAppConnect.tsx
@@ -6,7 +6,9 @@ import { Button } from '../ui/button';
 import { Badge } from '../ui/badge';
 import { Spinner } from '../ui/spinner';
 import { toast } from 'sonner';
-import { CheckCircle, XCircle, Unplug, Webhook, Phone, Building2, Shield, ExternalLink } from 'lucide-react';
+import { CheckCircle, XCircle, Unplug, Webhook, Phone, Building2, Shield, ExternalLink, KeyRound, AlertTriangle } from 'lucide-react';
+import { Input } from '../ui/input';
+import { Label } from '../ui/label';
 import type { WhatsAppConnectionStatus } from '../../types';
 
 declare global {
@@ -34,6 +36,13 @@ const WhatsAppConnect: React.FC<WhatsAppConnectProps> = ({ appId }) => {
     const [connecting, setConnecting] = useState(false);
     const [sdkReady, setSdkReady] = useState(false);
     const [metaAppId, setMetaAppId] = useState<string | null>(null);
+    const [showManualForm, setShowManualForm] = useState(false);
+    const [manualSubmitting, setManualSubmitting] = useState(false);
+    const [manualForm, setManualForm] = useState({
+        access_token: '',
+        waba_id: (import.meta.env.VITE_META_WABA_ID as string | undefined)?.trim() || '',
+        phone_number_id: (import.meta.env.VITE_META_PHONE_NUMBER_ID as string | undefined)?.trim() || '',
+    });
     const sdkLoadAttempted = useRef(false);
 
     const { data: status, loading, refetch } = useApiQuery<WhatsAppConnectionStatus>(
@@ -100,7 +109,36 @@ const WhatsAppConnect: React.FC<WhatsAppConnectProps> = ({ appId }) => {
                         })
                         .finally(() => setConnecting(false));
                 } else {
-                    toast.error('Meta login was cancelled or failed.');
+                    // Differentiate the common Facebook SDK failure modes so the
+                    // user knows whether to retry, ask for access, or use the
+                    // manual fallback. The most common cause for "App not active"
+                    // shown by FB is that the Meta App is in Development mode and
+                    // the logged-in FB user is not a Developer/Tester on it.
+                    const status = response.status;
+                    let msg = 'Meta login was cancelled.';
+                    let actionable = false;
+                    if (status === 'not_authorized') {
+                        msg = 'Meta declined the login. Most likely cause: the Meta App is in Development mode and your Facebook account is not listed as a Developer/Tester. Add yourself in App Dashboard > App Roles, or submit the app for App Review to go Live.';
+                        actionable = true;
+                    } else if (status === 'unknown') {
+                        msg = 'Meta returned an unknown status (often "App not active"). Verify the App is enabled and the WhatsApp Tech Provider use case is fully configured in App Dashboard.';
+                        actionable = true;
+                    }
+                    toast.error(msg, {
+                        duration: actionable ? 10_000 : 4_000,
+                        action: actionable
+                            ? {
+                                  label: 'Open App Dashboard',
+                                  onClick: () =>
+                                      window.open(
+                                          `https://developers.facebook.com/apps/${metaAppId}/dashboard/`,
+                                          '_blank',
+                                          'noopener,noreferrer'
+                                      ),
+                              }
+                            : undefined,
+                    });
+                    if (actionable) setShowManualForm(true);
                     setConnecting(false);
                 }
             },
@@ -140,6 +178,36 @@ const WhatsAppConnect: React.FC<WhatsAppConnectProps> = ({ appId }) => {
             setDisconnecting(false);
         }
     }, [appId, refetch]);
+
+    const handleManualConnect = useCallback(
+        async (e: React.FormEvent) => {
+            e.preventDefault();
+            if (!manualForm.access_token.trim() || !manualForm.waba_id.trim()) {
+                toast.error('Access token and WABA ID are required');
+                return;
+            }
+            setManualSubmitting(true);
+            try {
+                const data = await whatsappAdminAPI.manualConnect({
+                    app_id: appId,
+                    access_token: manualForm.access_token.trim(),
+                    waba_id: manualForm.waba_id.trim(),
+                    phone_number_id: manualForm.phone_number_id.trim() || undefined,
+                });
+                toast.success(`WhatsApp connected via System User token. Phone: ${data?.display_phone || 'configured'}`);
+                setShowManualForm(false);
+                setManualForm((f) => ({ ...f, access_token: '' }));
+                refetch();
+            } catch (err: any) {
+                toast.error(
+                    'Manual connect failed: ' + (err.response?.data?.message || err.message)
+                );
+            } finally {
+                setManualSubmitting(false);
+            }
+        },
+        [appId, manualForm, refetch]
+    );
 
     const handleSubscribeWebhooks = useCallback(async () => {
         setSubscribing(true);
@@ -256,7 +324,80 @@ const WhatsAppConnect: React.FC<WhatsAppConnectProps> = ({ appId }) => {
                                         )}
                                         {connecting ? 'Connecting...' : sdkReady ? 'Connect with Meta' : 'Loading SDK...'}
                                     </Button>
-                                ) : (
+                                ) : null}
+
+                                {hasSdkConfig && (
+                                    <button
+                                        type="button"
+                                        onClick={() => setShowManualForm((s) => !s)}
+                                        className="mt-2 text-xs text-muted-foreground underline-offset-2 hover:underline inline-flex items-center gap-1"
+                                    >
+                                        <KeyRound className="h-3 w-3" />
+                                        {showManualForm ? 'Hide' : 'Use a System User access token instead'}
+                                    </button>
+                                )}
+
+                                {showManualForm && (
+                                    <form
+                                        onSubmit={handleManualConnect}
+                                        className="mt-3 p-3 rounded-md border bg-background space-y-3"
+                                    >
+                                        <div className="flex items-start gap-2 text-xs text-muted-foreground">
+                                            <AlertTriangle className="h-4 w-4 mt-0.5 flex-shrink-0 text-amber-600" />
+                                            <span>
+                                                Use this while your Meta App is still in <strong>Development mode</strong> or pending
+                                                App Review. Generate a permanent System User token in{' '}
+                                                <a
+                                                    href="https://business.facebook.com/settings/system-users"
+                                                    target="_blank"
+                                                    rel="noopener noreferrer"
+                                                    className="underline"
+                                                >
+                                                    Business Settings &rarr; System Users
+                                                </a>
+                                                {' '}with <code>whatsapp_business_messaging</code> +{' '}
+                                                <code>whatsapp_business_management</code> scopes.
+                                            </span>
+                                        </div>
+                                        <div className="grid gap-2">
+                                            <Label htmlFor="manual-token" className="text-xs">System User Access Token</Label>
+                                            <Input
+                                                id="manual-token"
+                                                type="password"
+                                                autoComplete="off"
+                                                placeholder="EAAxxxxxxxxxxxxxx..."
+                                                value={manualForm.access_token}
+                                                onChange={(e) => setManualForm((f) => ({ ...f, access_token: e.target.value }))}
+                                            />
+                                        </div>
+                                        <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+                                            <div>
+                                                <Label htmlFor="manual-waba" className="text-xs">WABA ID</Label>
+                                                <Input
+                                                    id="manual-waba"
+                                                    placeholder="1660830174935643"
+                                                    value={manualForm.waba_id}
+                                                    onChange={(e) => setManualForm((f) => ({ ...f, waba_id: e.target.value }))}
+                                                />
+                                            </div>
+                                            <div>
+                                                <Label htmlFor="manual-phone" className="text-xs">Phone Number ID (optional)</Label>
+                                                <Input
+                                                    id="manual-phone"
+                                                    placeholder="auto-detected if omitted"
+                                                    value={manualForm.phone_number_id}
+                                                    onChange={(e) => setManualForm((f) => ({ ...f, phone_number_id: e.target.value }))}
+                                                />
+                                            </div>
+                                        </div>
+                                        <Button type="submit" size="sm" disabled={manualSubmitting}>
+                                            {manualSubmitting ? <Spinner className="h-4 w-4 mr-2" /> : <KeyRound className="h-4 w-4 mr-2" />}
+                                            {manualSubmitting ? 'Connecting...' : 'Connect via Token'}
+                                        </Button>
+                                    </form>
+                                )}
+
+                                {!hasSdkConfig && (
                                     <div className="space-y-3">
                                         <div className="p-3 rounded-md bg-amber-50 dark:bg-amber-950 border border-amber-200 dark:border-amber-800">
                                             <p className="text-sm text-amber-800 dark:text-amber-200 font-medium">Meta App ID not configured</p>

--- a/ui/src/pages/AppDetail.tsx
+++ b/ui/src/pages/AppDetail.tsx
@@ -16,6 +16,7 @@ import WorkflowsList from './workflows/WorkflowsList';
 import TemplateLibrary from './TemplateLibrary';
 import WhatsAppConnect from '../components/whatsapp/WhatsAppConnect';
 import WhatsAppTemplates from './whatsapp/WhatsAppTemplates';
+import WhatsAppRichTemplates from './whatsapp/WhatsAppRichTemplates';
 import WhatsAppConversations from './whatsapp/WhatsAppConversations';
 import TwilioWhatsAppTemplates from './whatsapp/TwilioWhatsAppTemplates';
 
@@ -334,6 +335,7 @@ const AppDetail: React.FC = () => {
                                 <WhatsAppConnect appId={app.app_id} />
                                 <TwilioWhatsAppTemplates apiKey={app.api_key} appId={app.app_id} />
                                 <WhatsAppTemplates apiKey={app.api_key} appId={app.app_id} />
+                                <WhatsAppRichTemplates apiKey={app.api_key} appId={app.app_id} />
                                 <WhatsAppConversations apiKey={app.api_key} appId={app.app_id} />
                             </div>
                         )}

--- a/ui/src/pages/whatsapp/WhatsAppRichTemplates.tsx
+++ b/ui/src/pages/whatsapp/WhatsAppRichTemplates.tsx
@@ -1,0 +1,424 @@
+import React, { useState } from 'react';
+import { whatsappRichTemplatesAPI } from '../../services/api';
+import { useApiQuery } from '../../hooks/use-api-query';
+import { Card, CardHeader, CardTitle, CardContent } from '../../components/ui/card';
+import { Button } from '../../components/ui/button';
+import { Input } from '../../components/ui/input';
+import { Label } from '../../components/ui/label';
+import { Badge } from '../../components/ui/badge';
+import { Spinner } from '../../components/ui/spinner';
+import EmptyState from '../../components/EmptyState';
+import { toast } from 'sonner';
+import { Plus, RefreshCw, Trash2, Eye, Layers, Tag, ExternalLink } from 'lucide-react';
+
+interface Props {
+    apiKey: string;
+    appId: string;
+}
+
+// approvalColors maps the aggregate ApprovalState (set server-side from
+// per-provider statuses) to a Tailwind badge class. Keep this in sync with
+// internal/domain/whatsapp/rich.go ApprovalState constants.
+const approvalColors: Record<string, string> = {
+    draft: 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-300',
+    pending: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
+    partially_submitted: 'bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200',
+    approved: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
+    rejected: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
+    disabled: 'bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-200',
+};
+
+// Shape of a card slot in the carousel builder form. Mirrors
+// internal/domain/whatsapp/rich.go CarouselCard so the POST body needs no
+// transformation beyond JSON serialisation.
+type DraftCard = {
+    header_image_url: string;
+    body: string;
+    button_text: string;
+    button_url: string;
+};
+
+type DraftKind = 'carousel' | 'coupon_code';
+
+const emptyCard = (): DraftCard => ({ header_image_url: '', body: '', button_text: 'View', button_url: '' });
+
+const WhatsAppRichTemplates: React.FC<Props> = ({ apiKey, appId }) => {
+    const [showCreate, setShowCreate] = useState(false);
+    const [creating, setCreating] = useState(false);
+    const [kind, setKind] = useState<DraftKind>('carousel');
+    const [draft, setDraft] = useState({
+        name: '',
+        category: 'MARKETING',
+        language: 'en_US',
+        body: '',
+        coupon_code: '',
+        cards: [emptyCard(), emptyCard()] as DraftCard[],
+    });
+
+    const { data, loading, refetch } = useApiQuery(
+        () => whatsappRichTemplatesAPI.list(apiKey),
+        [apiKey],
+        { enabled: !!apiKey, cacheKey: `wa-rich-templates-${appId}` },
+    );
+    const templates: any[] = data?.templates || [];
+
+    const addCard = () => setDraft({ ...draft, cards: [...draft.cards, emptyCard()] });
+    const removeCard = (idx: number) =>
+        setDraft({ ...draft, cards: draft.cards.filter((_, i) => i !== idx) });
+    const updateCard = (idx: number, patch: Partial<DraftCard>) =>
+        setDraft({ ...draft, cards: draft.cards.map((c, i) => (i === idx ? { ...c, ...patch } : c)) });
+
+    const handleCreate = async () => {
+        if (!draft.name) {
+            toast.error('Template name is required');
+            return;
+        }
+        const payload: any = {
+            name: draft.name,
+            kind,
+            category: draft.category,
+            language: draft.language,
+            body: draft.body,
+        };
+        if (kind === 'carousel') {
+            if (draft.cards.length < 2 || draft.cards.length > 10) {
+                toast.error('Carousel requires 2 to 10 cards');
+                return;
+            }
+            payload.cards = draft.cards.map((c) => ({
+                header_image_url: c.header_image_url,
+                body: c.body,
+                buttons: c.button_url
+                    ? [{ type: 'URL', text: c.button_text, url: c.button_url, track_clicks: true }]
+                    : [],
+            }));
+        } else if (kind === 'coupon_code') {
+            if (!draft.coupon_code) {
+                toast.error('Coupon code is required');
+                return;
+            }
+            payload.coupon_code = draft.coupon_code;
+        }
+
+        setCreating(true);
+        try {
+            await whatsappRichTemplatesAPI.create(apiKey, payload);
+            toast.success('Rich template submitted');
+            setShowCreate(false);
+            setDraft({
+                name: '',
+                category: 'MARKETING',
+                language: 'en_US',
+                body: '',
+                coupon_code: '',
+                cards: [emptyCard(), emptyCard()],
+            });
+            refetch();
+        } catch (err: any) {
+            // Validation errors come back as { error, details: [{field, message, code}] }
+            const details = err.response?.data?.details;
+            if (Array.isArray(details) && details.length > 0) {
+                toast.error(`Validation: ${details.map((d: any) => `${d.field}: ${d.message}`).join('; ')}`);
+            } else {
+                toast.error('Create failed: ' + (err.response?.data?.error || err.message));
+            }
+        } finally {
+            setCreating(false);
+        }
+    };
+
+    const handleDelete = async (id: string, name: string) => {
+        if (!confirm(`Delete rich template "${name}"? This cannot be undone.`)) return;
+        try {
+            await whatsappRichTemplatesAPI.delete(apiKey, id);
+            toast.success('Template deleted');
+            refetch();
+        } catch (err: any) {
+            toast.error('Delete failed: ' + (err.response?.data?.error || err.message));
+        }
+    };
+
+    const handleSync = async (id: string) => {
+        try {
+            await whatsappRichTemplatesAPI.sync(apiKey, id);
+            toast.success('Synced from Meta');
+            refetch();
+        } catch (err: any) {
+            toast.error('Sync failed: ' + (err.response?.data?.error || err.message));
+        }
+    };
+
+    const handlePreview = async (id: string) => {
+        try {
+            const preview = await whatsappRichTemplatesAPI.preview(apiKey, id);
+            // Open a side window with the JSON; cheap for now, the UI side-
+            // by-side preview is a follow-up.
+            const w = window.open('', '_blank', 'width=600,height=800');
+            if (w) {
+                w.document.write(
+                    `<pre style="padding:1rem;font:13px/1.4 monospace">${escapeHTML(
+                        JSON.stringify(preview, null, 2),
+                    )}</pre>`,
+                );
+            }
+        } catch (err: any) {
+            toast.error('Preview failed: ' + (err.response?.data?.error || err.message));
+        }
+    };
+
+    if (loading) {
+        return (
+            <div className="flex items-center justify-center py-16">
+                <Spinner className="h-6 w-6" />
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-6">
+            <div className="flex items-center justify-between">
+                <div>
+                    <h3 className="text-lg font-semibold">WhatsApp Rich Templates</h3>
+                    <p className="text-sm text-muted-foreground">
+                        Carousel and coupon-code templates with click attribution. Submitted to Meta on save; approval typically lands in &lt; 1 minute.
+                    </p>
+                </div>
+                <div className="flex gap-2">
+                    <Button variant="outline" size="sm" onClick={() => refetch()}>
+                        <RefreshCw className="h-4 w-4 mr-1" /> Refresh
+                    </Button>
+                    <Button size="sm" onClick={() => setShowCreate(!showCreate)}>
+                        <Plus className="h-4 w-4 mr-1" /> New Rich Template
+                    </Button>
+                </div>
+            </div>
+
+            {showCreate && (
+                <Card>
+                    <CardHeader>
+                        <CardTitle className="text-base">New Rich Template</CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-4">
+                        <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+                            <div className="space-y-2">
+                                <Label>Kind</Label>
+                                <select
+                                    className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm"
+                                    value={kind}
+                                    onChange={(e) => setKind(e.target.value as DraftKind)}
+                                >
+                                    <option value="carousel">Carousel</option>
+                                    <option value="coupon_code">Coupon Code</option>
+                                </select>
+                            </div>
+                            <div className="space-y-2">
+                                <Label>Name</Label>
+                                <Input
+                                    value={draft.name}
+                                    onChange={(e) => setDraft({ ...draft, name: e.target.value })}
+                                    placeholder="diwali_carousel"
+                                />
+                            </div>
+                            <div className="space-y-2">
+                                <Label>Category</Label>
+                                <select
+                                    className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm"
+                                    value={draft.category}
+                                    onChange={(e) => setDraft({ ...draft, category: e.target.value })}
+                                >
+                                    <option value="MARKETING">Marketing</option>
+                                    <option value="UTILITY">Utility</option>
+                                    <option value="AUTHENTICATION">Authentication</option>
+                                </select>
+                            </div>
+                            <div className="space-y-2">
+                                <Label>Language</Label>
+                                <Input
+                                    value={draft.language}
+                                    onChange={(e) => setDraft({ ...draft, language: e.target.value })}
+                                    placeholder="en_US"
+                                />
+                            </div>
+                        </div>
+
+                        <div className="space-y-2">
+                            <Label>Body</Label>
+                            <Input
+                                value={draft.body}
+                                onChange={(e) => setDraft({ ...draft, body: e.target.value })}
+                                placeholder="Hi {{1}}, check these out:"
+                            />
+                            <p className="text-xs text-muted-foreground">
+                                Use {'{{1}}'}, {'{{2}}'} … for variables. Variables must start at 1 and be contiguous.
+                            </p>
+                        </div>
+
+                        {kind === 'coupon_code' && (
+                            <div className="space-y-2">
+                                <Label>Coupon Code</Label>
+                                <Input
+                                    value={draft.coupon_code}
+                                    onChange={(e) => setDraft({ ...draft, coupon_code: e.target.value })}
+                                    placeholder="DEAL50"
+                                />
+                            </div>
+                        )}
+
+                        {kind === 'carousel' && (
+                            <div className="space-y-3">
+                                <div className="flex items-center justify-between">
+                                    <Label>Cards ({draft.cards.length} of 10)</Label>
+                                    <Button size="sm" variant="outline" onClick={addCard} disabled={draft.cards.length >= 10}>
+                                        <Plus className="h-3.5 w-3.5 mr-1" /> Add Card
+                                    </Button>
+                                </div>
+                                {draft.cards.map((c, i) => (
+                                    <Card key={i} className="p-3">
+                                        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                                            <div className="space-y-1">
+                                                <Label className="text-xs">Header Image URL</Label>
+                                                <Input
+                                                    value={c.header_image_url}
+                                                    onChange={(e) => updateCard(i, { header_image_url: e.target.value })}
+                                                    placeholder="https://cdn.example.com/p1.jpg"
+                                                />
+                                            </div>
+                                            <div className="space-y-1">
+                                                <Label className="text-xs">Body</Label>
+                                                <Input
+                                                    value={c.body}
+                                                    onChange={(e) => updateCard(i, { body: e.target.value })}
+                                                    placeholder="Polo {{1}} {{2}}"
+                                                />
+                                            </div>
+                                            <div className="space-y-1">
+                                                <Label className="text-xs">Button Text</Label>
+                                                <Input
+                                                    value={c.button_text}
+                                                    onChange={(e) => updateCard(i, { button_text: e.target.value })}
+                                                />
+                                            </div>
+                                            <div className="space-y-1">
+                                                <Label className="text-xs">Button URL (tracked)</Label>
+                                                <Input
+                                                    value={c.button_url}
+                                                    onChange={(e) => updateCard(i, { button_url: e.target.value })}
+                                                    placeholder="https://shop.example/p/{{1}}"
+                                                />
+                                            </div>
+                                        </div>
+                                        {draft.cards.length > 2 && (
+                                            <div className="flex justify-end mt-2">
+                                                <Button size="sm" variant="ghost" onClick={() => removeCard(i)}>
+                                                    <Trash2 className="h-3.5 w-3.5 mr-1" /> Remove
+                                                </Button>
+                                            </div>
+                                        )}
+                                    </Card>
+                                ))}
+                            </div>
+                        )}
+
+                        <div className="flex justify-end gap-2 pt-2">
+                            <Button variant="outline" onClick={() => setShowCreate(false)}>
+                                Cancel
+                            </Button>
+                            <Button onClick={handleCreate} disabled={creating}>
+                                {creating ? <Spinner className="h-4 w-4 mr-1" /> : null}
+                                Submit to Meta
+                            </Button>
+                        </div>
+                    </CardContent>
+                </Card>
+            )}
+
+            {templates.length === 0 ? (
+                <EmptyState
+                    icon={<Layers className="h-12 w-12" />}
+                    title="No rich templates yet"
+                    description="Create a carousel or coupon-code template to ship visually richer WhatsApp messages."
+                />
+            ) : (
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+                    {templates.map((t) => {
+                        const meta = t.providers?.meta;
+                        const twilio = t.providers?.twilio;
+                        return (
+                            <Card key={t.id} className="flex flex-col">
+                                <CardHeader className="pb-2">
+                                    <CardTitle className="text-base flex items-center justify-between gap-2">
+                                        <span className="truncate">{t.name}</span>
+                                        <Badge className={approvalColors[t.approval_state] || ''}>
+                                            {t.approval_state}
+                                        </Badge>
+                                    </CardTitle>
+                                    <p className="text-xs text-muted-foreground capitalize">
+                                        {t.kind?.replace('_', ' ')} · {t.language} · {t.category}
+                                    </p>
+                                </CardHeader>
+                                <CardContent className="flex-1 space-y-2 text-sm">
+                                    {t.body && (
+                                        <p className="text-muted-foreground line-clamp-2">{t.body}</p>
+                                    )}
+                                    {t.kind === 'carousel' && (
+                                        <p className="text-xs text-muted-foreground">
+                                            <Layers className="inline h-3 w-3 mr-1" />
+                                            {t.cards?.length || 0} cards
+                                        </p>
+                                    )}
+                                    {t.kind === 'coupon_code' && t.coupon_code && (
+                                        <p className="text-xs text-muted-foreground">
+                                            <Tag className="inline h-3 w-3 mr-1" />
+                                            {t.coupon_code}
+                                        </p>
+                                    )}
+                                    <div className="text-xs space-y-0.5">
+                                        {meta?.template_id && (
+                                            <p className="text-muted-foreground">
+                                                <span className="font-medium">Meta:</span> {meta.status || '—'}
+                                            </p>
+                                        )}
+                                        {twilio?.content_sid && (
+                                            <p className="text-muted-foreground">
+                                                <span className="font-medium">Twilio:</span> {twilio.status || '—'}
+                                            </p>
+                                        )}
+                                    </div>
+                                    <div className="flex flex-wrap gap-1 pt-2">
+                                        <Button size="sm" variant="outline" onClick={() => handlePreview(t.id)}>
+                                            <Eye className="h-3.5 w-3.5 mr-1" /> Preview
+                                        </Button>
+                                        <Button size="sm" variant="outline" onClick={() => handleSync(t.id)}>
+                                            <RefreshCw className="h-3.5 w-3.5 mr-1" /> Sync
+                                        </Button>
+                                        <Button size="sm" variant="ghost" onClick={() => handleDelete(t.id, t.name)}>
+                                            <Trash2 className="h-3.5 w-3.5" />
+                                        </Button>
+                                    </div>
+                                </CardContent>
+                            </Card>
+                        );
+                    })}
+                </div>
+            )}
+        </div>
+    );
+};
+
+// escapeHTML guards the JSON pre-window against XSS via header values
+// reflected in preview output (paranoid; we control all sources today).
+function escapeHTML(s: string): string {
+    return s
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+// ExternalLink imported but only used implicitly via the design system;
+// removing keeps lint clean. Re-export so future "Open in Meta Manager"
+// affordances can pick it up without re-importing.
+export { ExternalLink };
+
+export default WhatsAppRichTemplates;

--- a/ui/src/services/api.ts
+++ b/ui/src/services/api.ts
@@ -1302,6 +1302,19 @@ export const whatsappAdminAPI = {
     return data.data;
   },
 
+  // manualConnect skips Embedded Signup and stores a pre-existing System User
+  // access token directly. Use this while the Meta App is still in Development
+  // mode / pending App Review, or for self-hosted single-tenant deployments.
+  manualConnect: async (payload: {
+    app_id: string;
+    access_token: string;
+    waba_id: string;
+    phone_number_id?: string;
+  }) => {
+    const { data } = await api.post<ApiResponse<any>>('/admin/whatsapp/manual-connect', payload);
+    return data.data;
+  },
+
   disconnect: async (appId: string) => {
     const { data } = await api.post<{ success: boolean; message: string }>(`/admin/whatsapp/${appId}/disconnect`);
     return data;
@@ -1347,6 +1360,63 @@ export const whatsappTemplatesAPI = {
 
   sync: async (apiKey: string, name: string) => {
     const { data } = await api.post<ApiResponse<any>>(`/whatsapp/templates/${name}/sync`, {}, {
+      headers: getAuthHeaders(apiKey),
+    });
+    return data.data;
+  },
+};
+
+// ============= WhatsApp Rich-Template APIs (Phase 1-3 of rich plan) =============
+//
+// Authored carousels / coupons / cta_url / quick_reply / list templates that
+// FRN persists and submits to Meta (and Twilio in parallel when configured).
+// All endpoints are API-key protected and scoped by app via the auth header.
+export const whatsappRichTemplatesAPI = {
+  create: async (apiKey: string, payload: Record<string, any>) => {
+    const { data } = await api.post<ApiResponse<any>>('/whatsapp/rich-templates/', payload, {
+      headers: getAuthHeaders(apiKey),
+    });
+    return data.data;
+  },
+
+  list: async (
+    apiKey: string,
+    filters?: { kind?: string; status?: string; name_prefix?: string; limit?: number; offset?: number },
+  ) => {
+    const params = new URLSearchParams();
+    if (filters?.kind) params.set('kind', filters.kind);
+    if (filters?.status) params.set('status', filters.status);
+    if (filters?.name_prefix) params.set('name_prefix', filters.name_prefix);
+    if (filters?.limit != null) params.set('limit', String(filters.limit));
+    if (filters?.offset != null) params.set('offset', String(filters.offset));
+    const { data } = await api.get<ApiResponse<any[]> & { total: number }>(`/whatsapp/rich-templates/?${params}`, {
+      headers: getAuthHeaders(apiKey),
+    });
+    return { templates: data.data || [], total: data.total };
+  },
+
+  get: async (apiKey: string, id: string) => {
+    const { data } = await api.get<ApiResponse<any>>(`/whatsapp/rich-templates/${id}`, {
+      headers: getAuthHeaders(apiKey),
+    });
+    return data.data;
+  },
+
+  delete: async (apiKey: string, id: string) => {
+    await api.delete(`/whatsapp/rich-templates/${id}`, {
+      headers: getAuthHeaders(apiKey),
+    });
+  },
+
+  sync: async (apiKey: string, id: string) => {
+    const { data } = await api.post<ApiResponse<any>>(`/whatsapp/rich-templates/${id}/sync`, {}, {
+      headers: getAuthHeaders(apiKey),
+    });
+    return data.data;
+  },
+
+  preview: async (apiKey: string, id: string, variables?: Record<string, string>) => {
+    const { data } = await api.post<ApiResponse<any>>(`/whatsapp/rich-templates/${id}/preview`, { variables }, {
       headers: getAuthHeaders(apiKey),
     });
     return data.data;


### PR DESCRIPTION


- Domain: rich template models, validator, click-signer with HMAC tracking signatures
- Service: end-to-end rich template lifecycle (Create/Sync/Preview/Send) with Meta Graph submission, Resumable Upload for header media, and Twilio Content API sync
- Worker: SetWhatsAppRichTemplateService + resolveWhatsAppRich resolver — Meta path expands to wire-format payload, Twilio path lifts content_sid + content_variables with <card>.<position> notation
- Providers: meta_whatsapp_provider buildRichMessage routes commerce + template kinds; tests added
- Handlers: WhatsAppRichTemplate CRUD, Twilio content-status webhook, Twilio inbound webhook with HMAC-SHA1 signature validation, click redirect with HMAC verify
- Validators: SendRequest + BroadcastRequest accept data.whatsapp_rich.template_id in lieu of content_sid
- Repo + indices: whatsapp_rich_templates + analytics_event_repo; index_manager + templates updated
- UI: WhatsAppRichTemplates page + API surface; WhatsAppConnect refinements
- Docs: OpenAPI fragment (docs/openapi/whatsapp-rich.yaml), API_DOCUMENTATION appendix, Meta app review video script
- Tests: validate_test, click_signer_test, meta_whatsapp_provider_test, meta_webhook_handler_test, whatsapp_rich_template_service_test, e2e/whatsapp-carousel.spec.ts