### PR TITLE
Support user_id and external_id as recipient identifiers

### DIFF
--- a/docs/openapi/otp.yaml
+++ b/docs/openapi/otp.yaml
@@ -1,0 +1,321 @@
+# OTP-as-a-Service — OpenAPI Fragment
+#
+# Documents the public OTP API exposed under /v1/otp/*. The endpoints are
+# protected by the standard X-API-Key middleware (tenant is derived server-side
+# from the key, never from the request body).
+#
+# Endpoints:
+#   POST /v1/otp/send    — generate + dispatch a code via SMS, WhatsApp, or email
+#   POST /v1/otp/verify  — verify a code against a request_id (constant-time)
+#   POST /v1/otp/resend  — re-issue a fresh code for an existing request_id
+#
+# Implementation notes (for reviewers, not for API consumers):
+#   - Codes are persisted as SHA-256(code + per-record salt); plaintext is
+#     discarded immediately after dispatch and never logged.
+#   - Verify uses crypto/subtle constant-time compare and atomic Redis
+#     WATCH/MULTI attempt-increments to prevent brute-force races.
+#   - Send reuses the standard notification pipeline (templates, providers,
+#     credit billing) — there is no separate OTP rate card.
+openapi: 3.0.3
+info:
+  title: FreeRangeNotify — OTP as a Service
+  version: "1.0.0"
+  description: |
+    Programmatic one-time-passcode delivery and verification over SMS,
+    WhatsApp, and email. Designed for sign-in, sign-up, step-up auth,
+    and transaction confirmation flows.
+
+servers:
+  - url: http://localhost:8080/v1
+    description: Local development
+
+security:
+  - ApiKeyAuth: []
+
+paths:
+  /otp/send:
+    post:
+      summary: Send an OTP
+      description: |
+        Generates a one-time passcode, hashes it for storage, and dispatches
+        it to the recipient through the requested channel. The response
+        returns a `request_id` that the client must echo back to
+        `POST /otp/verify`. The plaintext code is never returned by the API.
+
+        Subject to the configured per-recipient rate limit (default: 5 sends
+        per app/recipient per 10 minutes).
+      operationId: sendOTP
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/OTPSendRequest" }
+            examples:
+              sms:
+                summary: SMS, defaults
+                value:
+                  channel: sms
+                  recipient: "+14155551212"
+              whatsapp:
+                summary: WhatsApp with custom body
+                value:
+                  channel: whatsapp
+                  recipient: "+14155551212"
+                  template_body: "Your verification code is {{code}}. Expires in {{ttl}} minutes."
+              email_alpha:
+                summary: Email, 8-char alphanumeric, 10-min TTL
+                value:
+                  channel: email
+                  recipient: "user@example.com"
+                  length: 8
+                  alphanumeric: true
+                  ttl_seconds: 600
+                  template_data: { app_name: "Acme" }
+              by_external_id:
+                summary: Email to a known user, identified by external_id
+                value:
+                  channel: email
+                  external_id: "customer_ext_42"
+              by_user_id:
+                summary: SMS to a known user, identified by internal user_id
+                value:
+                  channel: sms
+                  user_id: "11111111-2222-3333-4444-555555555555"
+      responses:
+        "202":
+          description: OTP queued for delivery
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/OTPSendResponse" }
+        "400": { $ref: "#/components/responses/ValidationError" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "429": { $ref: "#/components/responses/RateLimited" }
+        "500": { $ref: "#/components/responses/InternalError" }
+
+  /otp/verify:
+    post:
+      summary: Verify an OTP
+      description: |
+        Verifies a code against the `request_id` returned by `/otp/send`.
+        Comparison is constant-time and the attempt counter is incremented
+        atomically. Returns `200` on success and on a recoverable invalid
+        attempt (with `verified=false` and `attempts_remaining` in the body)
+        so clients can render UX without an extra round-trip. Hard failures
+        (expired, not_found) return `4xx`.
+      operationId: verifyOTP
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/OTPVerifyRequest" }
+      responses:
+        "200":
+          description: Verification succeeded
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/OTPVerifyResponse" }
+        "400":
+          description: Invalid code or attempts exhausted
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/OTPVerifyResponse" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "404":
+          description: request_id not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/OTPVerifyResponse" }
+        "410":
+          description: OTP expired
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/OTPVerifyResponse" }
+
+  /otp/resend:
+    post:
+      summary: Resend an OTP
+      description: |
+        Mints a **new** code for the same `request_id`, invalidates the
+        previous code, and resets the attempt counter. Subject to a 60-second
+        cooldown per request_id.
+      operationId: resendOTP
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/OTPResendRequest" }
+      responses:
+        "202":
+          description: New OTP queued for delivery
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/OTPSendResponse" }
+        "400": { $ref: "#/components/responses/ValidationError" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "409":
+          description: Already verified or still in cooldown
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "410": { $ref: "#/components/responses/Gone" }
+        "429": { $ref: "#/components/responses/RateLimited" }
+
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key
+
+  schemas:
+    Channel:
+      type: string
+      enum: [sms, whatsapp, email]
+      description: Delivery channel for the OTP.
+
+    OTPSendRequest:
+      type: object
+      required: [channel]
+      description: |
+        The recipient is identified by EXACTLY ONE of `recipient`, `user_id`,
+        or `external_id`. When `user_id` / `external_id` is supplied, the
+        channel-appropriate contact field on the resolved user record (email
+        for `email`; phone for `sms`/`whatsapp`) is used as the destination.
+      properties:
+        channel: { $ref: "#/components/schemas/Channel" }
+        recipient:
+          type: string
+          description: |
+            Raw E.164 phone number for `sms`/`whatsapp` (e.g. `+14155551212`)
+            or a valid email address for `email`. Mutually exclusive with
+            `user_id` and `external_id`.
+          example: "+14155551212"
+        user_id:
+          type: string
+          description: |
+            Internal FreeRangeNotify `user_id` (UUID). When set, the channel
+            address is read from the user record. Mutually exclusive with
+            `recipient` and `external_id`.
+          example: "11111111-2222-3333-4444-555555555555"
+        external_id:
+          type: string
+          description: |
+            Caller-owned user identifier resolved via the users index.
+            Mutually exclusive with `recipient` and `user_id`.
+          example: "customer_ext_42"
+        length:
+          type: integer
+          minimum: 4
+          maximum: 10
+          default: 6
+          description: Number of characters in the code.
+        alphanumeric:
+          type: boolean
+          default: false
+          description: |
+            If `true`, codes are drawn from a lookalike-free alphabet
+            (`ABCDEFGHJKLMNPQRSTUVWXYZ23456789`) instead of digits 0–9.
+        ttl_seconds:
+          type: integer
+          minimum: 30
+          maximum: 900
+          default: 300
+          description: Code lifetime in seconds (max 15 minutes).
+        max_attempts:
+          type: integer
+          minimum: 1
+          maximum: 10
+          default: 5
+          description: Maximum number of verify attempts before lockout.
+        template_body:
+          type: string
+          description: |
+            Optional message body. Must contain a `{{code}}` placeholder.
+            May also reference `{{ttl}}` (TTL in minutes) and any keys from
+            `template_data`. If omitted, a channel-appropriate default is used.
+        template_data:
+          type: object
+          additionalProperties: true
+          description: Extra variables for `template_body` (e.g. `{ "app_name": "Acme" }`).
+
+    OTPSendResponse:
+      type: object
+      properties:
+        request_id:        { type: string, example: "550e8400-e29b-41d4-a716-446655440000" }
+        notification_id:   { type: string, example: "abc123" }
+        channel:           { $ref: "#/components/schemas/Channel" }
+        expires_at:        { type: string, format: date-time }
+        ttl_seconds:       { type: integer, example: 300 }
+        max_attempts:      { type: integer, example: 5 }
+
+    OTPVerifyRequest:
+      type: object
+      required: [request_id, code]
+      properties:
+        request_id: { type: string }
+        code:
+          type: string
+          minLength: 4
+          maxLength: 10
+          example: "482913"
+
+    OTPVerifyResponse:
+      type: object
+      properties:
+        verified:           { type: boolean }
+        request_id:         { type: string }
+        verified_at:
+          type: string
+          format: date-time
+          nullable: true
+        attempts_remaining:
+          type: integer
+          description: Present on `invalid_code`. Omitted on success.
+        error:
+          type: string
+          enum: [invalid_code, attempts_exhausted, expired, not_found, internal_error]
+          description: Present only when `verified=false`.
+
+    OTPResendRequest:
+      type: object
+      required: [request_id]
+      properties:
+        request_id: { type: string }
+
+    Error:
+      type: object
+      properties:
+        error: { type: string }
+
+  responses:
+    ValidationError:
+      description: Request payload failed validation
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/Error" }
+    Unauthorized:
+      description: Missing or invalid API key
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/Error" }
+    NotFound:
+      description: request_id not found
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/Error" }
+    Gone:
+      description: OTP expired
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/Error" }
+    RateLimited:
+      description: Per-recipient rate limit exceeded
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/Error" }
+    InternalError:
+      description: Server-side failure
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/Error" }

--- a/documents/API_DOCUMENTATION.md
+++ b/documents/API_DOCUMENTATION.md
@@ -727,3 +727,173 @@ Buttons with `track_clicks: true` are wrapped at render-time with a signed `/v1/
 
 - `POST /v1/webhooks/twilio/content-status` — Twilio Content API approval updates. The handler maps `ContentSid` → FRN-side `TwilioBinding` via the rich-template service. Always returns 200 to prevent retries.
 - `POST /v1/webhooks/twilio/whatsapp` — Twilio Programmable Messaging inbound webhook for replies, button taps, and list selections. Resolves the target FRN app by matching `To` against `application.Settings.WhatsApp.FromNumber`, then forwards a normalised `InboundMessage` to the WhatsApp service which emits `whatsapp.button_clicked` / `whatsapp.list_selected` / `whatsapp.text_received` workflow events. Signature is verified against `providers.whatsapp.auth_token` when configured; requests with a bad signature are rejected with `403`.
+
+---
+
+## OTP as a Service
+
+OpenAPI fragment: [docs/openapi/otp.yaml](../docs/openapi/otp.yaml).
+
+A programmatic one-time-passcode API for sign-in, sign-up, step-up auth, and transaction confirmation flows over **SMS**, **WhatsApp**, and **Email**. The send path reuses the standard notification pipeline (templates, providers, credit billing); the verify path adds constant-time comparison, atomic attempt counting, and per-recipient rate limiting that is not safe for customers to reimplement on top of `/v1/notifications` directly.
+
+### Endpoints
+
+| Method | Path             | Purpose                                          |
+| ------ | ---------------- | ------------------------------------------------ |
+| POST   | `/v1/otp/send`   | Generate a code, hash it, dispatch via channel   |
+| POST   | `/v1/otp/verify` | Verify a code against a `request_id`             |
+| POST   | `/v1/otp/resend` | Re-issue a fresh code (60 s cooldown per record) |
+
+All three require the `X-API-Key` header. `app_id` is derived from the key server-side — never accepted from the request body.
+
+### Quick start
+
+**1. Send a code (SMS, defaults — 6 digits, 5 minutes, 5 attempts):**
+
+```bash
+curl -X POST http://localhost:8080/v1/otp/send \
+  -H "X-API-Key: $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"channel":"sms","recipient":"+14155551212"}'
+```
+
+```json
+{
+  "request_id": "550e8400-e29b-41d4-a716-446655440000",
+  "notification_id": "abc123",
+  "channel": "sms",
+  "expires_at": "2026-05-24T12:35:00Z",
+  "ttl_seconds": 300,
+  "max_attempts": 5
+}
+```
+
+**2. Verify the code:**
+
+```bash
+curl -X POST http://localhost:8080/v1/otp/verify \
+  -H "X-API-Key: $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"request_id":"550e8400-e29b-41d4-a716-446655440000","code":"482913"}'
+```
+
+Success: `200 OK` with `{"verified": true, "verified_at": "..."}`.
+Wrong code: `400` with `{"verified": false, "error": "invalid_code", "attempts_remaining": 4}`.
+
+**3. Resend (after the 60 s cooldown):**
+
+```bash
+curl -X POST http://localhost:8080/v1/otp/resend \
+  -H "X-API-Key: $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"request_id":"550e8400-e29b-41d4-a716-446655440000"}'
+```
+
+### Channels & recipient formats
+
+The recipient is identified by **exactly one** of three body fields. The `channel` field selects which contact address is used.
+
+| Identifier   | What you pass                            | Resolution                                                                                         |
+| ------------ | ---------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `recipient`  | Raw email / E.164 phone                  | Auto-creates a user record (with `EmailEnabled`/`SMSEnabled`/`WhatsAppEnabled` all `true`) on first send. |
+| `user_id`    | Internal FRN `user_id` (UUID)            | Loads the user record; uses `email` for `email`-channel sends and `phone` for `sms`/`whatsapp`. Cross-tenant probes return `404`. |
+| `external_id`| Caller-owned external identifier         | Looked up via the users index; same channel-address rules as `user_id`.                            |
+
+Raw-recipient address formats:
+
+| Channel    | Format                            |
+| ---------- | --------------------------------- |
+| `sms`      | E.164, e.g. `+14155551212`        |
+| `whatsapp` | E.164, e.g. `+14155551212`        |
+| `email`    | RFC 5322 address                  |
+
+When `user_id` / `external_id` is supplied but the resolved user has no value for the field the channel needs, the API returns `400` with `error: "otp: resolved user has no address for the requested channel"`.
+
+Example — send by `external_id`:
+
+```bash
+curl -X POST http://localhost:8080/v1/otp/send \
+  -H "X-API-Key: $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"channel":"email","external_id":"customer_ext_42"}'
+```
+
+### Customising the message body
+
+Bring-your-own body via `template_body`. It **must** contain a `{{code}}` placeholder. Supported placeholders:
+
+| Placeholder                          | Value                                |
+| ------------------------------------ | ------------------------------------ |
+| `{{code}}`, `{{ code }}`, `{{.code}}`| The generated OTP                    |
+| `{{ttl}}`, `{{ ttl }}`, `{{.ttl}}`   | TTL **in minutes** (e.g. `5`)        |
+| `{{<key>}}` from `template_data`     | Any extra string variable you pass   |
+
+Example:
+
+```json
+{
+  "channel": "whatsapp",
+  "recipient": "+14155551212",
+  "template_body": "Your {{app_name}} code is {{code}}. Expires in {{ttl}} minutes.",
+  "template_data": { "app_name": "Acme" }
+}
+```
+
+If `template_body` is omitted, a channel-appropriate default is used (e.g. `Your verification code is 482913. It expires in 5 minutes.`).
+
+### Code generation knobs
+
+| Field          | Default | Range  | Behaviour                                                                                                       |
+| -------------- | ------- | ------ | --------------------------------------------------------------------------------------------------------------- |
+| `length`       | 6       | 4–10   | Number of characters in the code.                                                                               |
+| `alphanumeric` | false   |        | When `true`, codes draw from `ABCDEFGHJKLMNPQRSTUVWXYZ23456789` — lookalikes `0/O`, `1/I/l` are excluded.       |
+| `ttl_seconds`  | 300     | 30–900 | Code lifetime (max 15 minutes).                                                                                 |
+| `max_attempts` | 5       | 1–10   | Verify attempts allowed before the record is locked out (`attempts_exhausted`).                                  |
+
+### Security model
+
+- **Storage**: Only `SHA-256(code + 16-byte random salt)` is persisted in Redis under `frn:otp:api:<request_id>`. The plaintext code is discarded immediately after dispatch and is never logged.
+- **Verification**: `crypto/subtle.ConstantTimeCompare` guards against timing oracles. Attempt counting uses an atomic Redis `WATCH/MULTI` loop so concurrent guesses cannot exceed `max_attempts`.
+- **Per-recipient rate limit**: A fixed window of 5 sends per `(app_id, recipient)` per 10 minutes (`frn:otp:rl:...`). Exceeding it returns `429`.
+- **Resend cooldown**: 60 seconds per `request_id`, enforced server-side. Resend re-mints a new code and resets the attempt counter; the previous code is invalidated.
+- **Tenant isolation**: `app_id` is sourced from `c.Locals("app_id")` set by the API-key middleware. Cross-tenant `request_id` access is impossible because each record is keyed by a v4 UUID issued by FRN.
+
+### Error reference
+
+| HTTP | `error`              | Cause                                                            | Endpoint(s)         |
+| ---- | -------------------- | ---------------------------------------------------------------- | ------------------- |
+| 400  | _validation message_ | Bad JSON, missing required field, or DTO tag violation           | send / verify / resend |
+| 400  | _validation message_ | Invalid channel, recipient, length, TTL, attempts, or template   | send / resend       |
+| 400  | `invalid_code`       | Code mismatch (response also carries `attempts_remaining`)       | verify              |
+| 400  | `attempts_exhausted` | `max_attempts` reached on this `request_id`                      | verify              |
+| 401  | _auth message_       | Missing / invalid `X-API-Key`                                    | all                 |
+| 404  | `not_found`          | `request_id` does not exist (or already expired and purged)      | verify / resend     |
+| 409  | `already_verified`   | The OTP was already consumed                                     | resend              |
+| 409  | `resend_cooldown`    | Within the 60 s cooldown                                         | resend              |
+| 410  | `expired`            | OTP TTL elapsed                                                  | verify / resend     |
+| 429  | `rate_limited`       | Per-recipient send budget exceeded                               | send / resend       |
+| 500  | `internal_error`     | Unhandled server failure                                         | all                 |
+
+### Billing
+
+Each `send` (and each `resend`) dispatches one notification through the standard pipeline, which charges the per-channel credit rate just like `/v1/notifications`. **There is no separate OTP rate card.** The OTP endpoints are a thin policy layer (generate → hash → verify) on top of channels you are already paying for.
+
+### UI integration
+
+The FRN dashboard intentionally does **not** expose OTP authoring/inspection screens in v1. Rationale:
+
+- The OTP API is a programmatic, server-to-server feature consumed by customer applications via curl / SDKs — not by dashboard operators.
+- The dashboard already exposes template editors and an ad-hoc "Send SMS" composer for operator-driven messaging; reusing those surfaces for OTP would conflate ephemeral auth state with persisted broadcast templates.
+- OTP records are short-lived (≤ 15 minutes) and security-sensitive (plaintext discarded, salt rotated per record), so a "browse recent OTPs" panel would either be useless (only hashes) or actively harmful (if it leaked plaintext into the UI).
+- Standard delivery analytics (provider status, latency, cost) for each OTP are already visible via the linked `notification_id` in the existing notifications dashboard.
+
+A future "Auth diagnostics" panel surfacing `request_id`, channel, status, and attempts (without ever exposing the code) can be added if customer demand materialises; it is explicitly out of scope here.
+
+### SDKs
+
+Both first-party SDKs ship typed OTP sub-clients:
+
+- **Go** — `client.OTP.Send / Verify / Resend` with `errors.Is`-matchable sentinels (`ErrOTPInvalidCode`, `ErrOTPAttemptsExhausted`, `ErrOTPExpired`, `ErrOTPNotFound`, `ErrOTPAlreadyVerified`, `ErrOTPResendCooldown`, `ErrOTPRateLimited`). The underlying `*APIError` is reachable via `errors.As`.
+- **TypeScript / JavaScript** — `client.otp.send / verify / resend` throwing `OTPError` with a typed `code` discriminator (`invalid_code` · `attempts_exhausted` · `expired` · `not_found` · `already_verified` · `resend_cooldown` · `rate_limited`). On `invalid_code`, `err.attemptsRemaining` is populated.
+
+See the in-product docs (`/docs/otp` in the dashboard) for runnable Go and TypeScript snippets covering the full send → verify → resend flow.

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -92,6 +92,7 @@ type Container struct {
 	SSEHandler                   *handlers.SSEHandler
 	AuthHandler                  *handlers.AuthHandler
 	QuickSendHandler             *handlers.QuickSendHandler
+	OTPHandler                   *handlers.OTPHandler
 	PlaygroundHandler            *handlers.PlaygroundHandler
 	AnalyticsHandler             *handlers.AnalyticsHandler
 	LicensingHandler             *handlers.LicensingHandler
@@ -109,6 +110,9 @@ type Container struct {
 
 	// Quick-Send
 	QuickSendService *usecases.QuickSendService
+
+	// OTP-as-a-service (public API for customers to send/verify OTPs)
+	OTPService *services.OTPService
 
 	// Workflow Engine (Phase 1 — feature-gated)
 	WorkflowService workflow.Service
@@ -507,6 +511,23 @@ func NewContainer(cfg *config.Config, logger *zap.Logger) (*Container, error) {
 		logger,
 	)
 	container.QuickSendHandler.SetIdempotencyStore(container.IdempotencyStore)
+
+	// OTP-as-a-service: customer-facing API to send and verify codes via
+	// SMS, WhatsApp, or email. Code dispatch flows through the standard
+	// NotificationService so credit metering, audit, and retries all apply.
+	otpAPIRepo := repository.NewOTPAPIRepository(container.RedisClient)
+	container.OTPService = services.NewOTPService(
+		otpAPIRepo,
+		container.NotificationService,
+		repos.User,
+		container.TemplateService,
+		logger,
+	)
+	container.OTPHandler = handlers.NewOTPHandler(
+		container.OTPService,
+		container.Validator,
+		logger,
+	)
 
 	// Playground handler
 	var playgroundBaseURL string

--- a/internal/domain/otp/models.go
+++ b/internal/domain/otp/models.go
@@ -1,0 +1,165 @@
+// Package otp defines the public OTP-as-a-service domain.
+//
+// This is separate from the internal auth OTP used during FRN account
+// registration (see internal/usecases/services/auth_service_impl.go) — that
+// flow is for FRN's own users, while this package serves FRN customers who
+// need to send and verify OTPs to their own end users via SMS, WhatsApp, or
+// email.
+package otp
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// Channel enumerates the delivery channels supported by the OTP service.
+type Channel string
+
+const (
+	ChannelSMS      Channel = "sms"
+	ChannelWhatsApp Channel = "whatsapp"
+	ChannelEmail    Channel = "email"
+)
+
+// Valid reports whether the channel is a supported OTP delivery channel.
+func (c Channel) Valid() bool {
+	switch c {
+	case ChannelSMS, ChannelWhatsApp, ChannelEmail:
+		return true
+	}
+	return false
+}
+
+// Defaults applied when the caller omits a tuneable parameter.
+const (
+	DefaultCodeLength       = 6
+	DefaultTTLSeconds       = 300
+	DefaultMaxAttempts      = 5
+	DefaultResendCooldownS  = 60
+	MinCodeLength           = 4
+	MaxCodeLength           = 10
+	MaxTTLSeconds           = 15 * 60 // 15 minutes upper bound to prevent stale codes
+	MaxAttemptsCap          = 10
+	MinAttempts             = 1
+)
+
+// Sentinel errors. Kept stable so callers (handlers, tests) can use
+// errors.Is() for branch logic.
+var (
+	ErrInvalidChannel      = errors.New("otp: invalid channel")
+	ErrInvalidRecipient    = errors.New("otp: invalid recipient")
+	ErrInvalidLength       = errors.New("otp: invalid code length")
+	ErrInvalidTTL          = errors.New("otp: invalid ttl")
+	ErrInvalidAttempts     = errors.New("otp: invalid max_attempts")
+	ErrTemplateMissingCode = errors.New("otp: template body must contain {{code}} placeholder")
+	ErrNotFound            = errors.New("otp: request not found or expired")
+	ErrExpired             = errors.New("otp: code expired")
+	ErrAttemptsExhausted   = errors.New("otp: maximum verification attempts exhausted")
+	ErrInvalidCode         = errors.New("otp: invalid code")
+	ErrAlreadyVerified     = errors.New("otp: code already verified")
+	ErrResendCooldown      = errors.New("otp: resend cooldown in effect")
+	ErrRateLimited         = errors.New("otp: rate limit exceeded for recipient")
+	// ErrAmbiguousRecipient is returned when the caller supplies more than one
+	// of {recipient, user_id, external_id}. The API contract requires exactly one.
+	ErrAmbiguousRecipient = errors.New("otp: provide exactly one of recipient, user_id, or external_id")
+	// ErrUserNotFound is returned when a user_id or external_id lookup misses.
+	ErrUserNotFound = errors.New("otp: user not found")
+	// ErrUserMissingChannelAddress is returned when a resolved user lacks the
+	// contact field required by the requested channel (e.g. channel=email but
+	// the user record has no email).
+	ErrUserMissingChannelAddress = errors.New("otp: resolved user has no address for the requested channel")
+)
+
+// Request is the persisted OTP envelope. CodeHash and Salt together let us
+// verify a code in constant time without ever storing the plaintext.
+type Request struct {
+	RequestID    string    `json:"request_id"`
+	AppID        string    `json:"app_id"`
+	Channel      Channel   `json:"channel"`
+	Recipient    string    `json:"recipient"` // E.164 phone or RFC-5322 email
+	CodeHash     string    `json:"code_hash"` // hex-encoded SHA-256(code || salt)
+	Salt         string    `json:"salt"`      // hex-encoded random 16 bytes
+	Length       int       `json:"length"`
+	Alphanumeric bool      `json:"alphanumeric"`
+	Attempts     int       `json:"attempts"`
+	MaxAttempts  int       `json:"max_attempts"`
+	ExpiresAt    time.Time `json:"expires_at"`
+	LastSentAt   time.Time `json:"last_sent_at"`
+	Verified     bool      `json:"verified"`
+	VerifiedAt   *time.Time `json:"verified_at,omitempty"`
+	CreatedAt    time.Time `json:"created_at"`
+}
+
+// SendInput is the use-case input for OTPService.Send. The caller must
+// identify the recipient using EXACTLY ONE of the three identifier fields:
+//   - Recipient: raw email / E.164 phone (no user lookup; auto-creates a user)
+//   - UserID:    internal FRN user_id (UUID); the channel address is read off the record
+//   - ExternalID: caller-owned user identifier; resolved via the users index
+// When UserID or ExternalID is used, the contact field corresponding to the
+// channel is read from the user record (Email for email; Phone for sms/whatsapp).
+// Validation lives on the DTO layer (interfaces/http/dto/otp_dto.go) so the
+// service can assume inputs are syntactically well-formed and focus on policy.
+type SendInput struct {
+	AppID        string
+	Channel      Channel
+	Recipient    string // mutually exclusive with UserID / ExternalID
+	UserID       string // mutually exclusive with Recipient / ExternalID
+	ExternalID   string // mutually exclusive with Recipient / UserID
+	Length       int    // 0 → DefaultCodeLength
+	Alphanumeric bool
+	TTLSeconds   int                    // 0 → DefaultTTLSeconds
+	MaxAttempts  int                    // 0 → DefaultMaxAttempts
+	TemplateBody string                 // optional BYO body containing {{code}}; empty → system default
+	TemplateData map[string]interface{} // extra template vars (e.g. {{app_name}})
+}
+
+// SendResult is what SendOTP returns once the underlying notification has
+// been queued. NotificationID is included so callers can correlate the OTP
+// with the notification pipeline for audit / delivery-status purposes.
+type SendResult struct {
+	RequestID      string
+	NotificationID string
+	Channel        Channel
+	ExpiresAt      time.Time
+	TTLSeconds     int
+	MaxAttempts    int
+}
+
+// VerifyInput is the use-case input for OTPService.Verify.
+type VerifyInput struct {
+	RequestID string
+	Code      string
+}
+
+// VerifyResult reports the outcome of a verification attempt. AttemptsRemaining
+// is included on failure so callers can render UX without an extra round-trip.
+type VerifyResult struct {
+	Verified           bool
+	AttemptsRemaining  int
+	VerifiedAt         *time.Time
+}
+
+// Service is the public OTP-as-a-service contract. Implementations must be
+// safe for concurrent use.
+type Service interface {
+	Send(ctx context.Context, in SendInput) (*SendResult, error)
+	Verify(ctx context.Context, in VerifyInput) (*VerifyResult, error)
+	Resend(ctx context.Context, requestID string) (*SendResult, error)
+}
+
+// Repository is the storage contract. The Redis-backed implementation keys
+// records by RequestID with a TTL matching ExpiresAt. Implementations must
+// be atomic on IncrementAttempts to prevent brute-force races.
+type Repository interface {
+	Create(ctx context.Context, req *Request) error
+	Get(ctx context.Context, requestID string) (*Request, error)
+	IncrementAttempts(ctx context.Context, requestID string) (int, error)
+	MarkVerified(ctx context.Context, requestID string, verifiedAt time.Time) error
+	Update(ctx context.Context, req *Request) error
+	Delete(ctx context.Context, requestID string) error
+
+	// RecipientRateLimit increments and reads a per-app-per-recipient counter
+	// over a rolling window. Returns the new count after increment.
+	RecipientRateLimit(ctx context.Context, appID, recipient string, windowSeconds int) (int, error)
+}

--- a/internal/domain/otp/models_test.go
+++ b/internal/domain/otp/models_test.go
@@ -1,0 +1,41 @@
+package otp
+
+import (
+	"testing"
+)
+
+func TestChannel_Valid(t *testing.T) {
+	cases := []struct {
+		in   Channel
+		want bool
+	}{
+		{ChannelSMS, true},
+		{ChannelWhatsApp, true},
+		{ChannelEmail, true},
+		{Channel(""), false},
+		{Channel("push"), false},
+		{Channel("SMS"), false}, // case-sensitive on purpose
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.in), func(t *testing.T) {
+			if got := tc.in.Valid(); got != tc.want {
+				t.Errorf("Channel(%q).Valid() = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDefaults_Sanity(t *testing.T) {
+	if DefaultCodeLength < MinCodeLength || DefaultCodeLength > MaxCodeLength {
+		t.Errorf("DefaultCodeLength %d outside [%d,%d]", DefaultCodeLength, MinCodeLength, MaxCodeLength)
+	}
+	if DefaultMaxAttempts < MinAttempts || DefaultMaxAttempts > MaxAttemptsCap {
+		t.Errorf("DefaultMaxAttempts %d outside [%d,%d]", DefaultMaxAttempts, MinAttempts, MaxAttemptsCap)
+	}
+	if DefaultTTLSeconds <= 0 || DefaultTTLSeconds > MaxTTLSeconds {
+		t.Errorf("DefaultTTLSeconds %d invalid", DefaultTTLSeconds)
+	}
+	if DefaultResendCooldownS <= 0 {
+		t.Errorf("DefaultResendCooldownS must be positive")
+	}
+}

--- a/internal/infrastructure/repository/otp_api_repository.go
+++ b/internal/infrastructure/repository/otp_api_repository.go
@@ -1,0 +1,179 @@
+package repository
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/go-redis/redis/v8"
+
+	"github.com/the-monkeys/freerangenotify/internal/domain/otp"
+)
+
+// otpAPIPrefix namespaces this repository's keys to avoid collisions with the
+// internal auth-OTP repository (otp_repository.go), which uses "frn:otp:register:"
+// and "frn:otp:phone:". The "api" segment makes the public OTP-as-a-service
+// keyspace explicit.
+const (
+	otpAPIPrefix         = "frn:otp:api:"
+	otpRecipientRLPrefix = "frn:otp:rl:"
+)
+
+type redisOTPAPIRepository struct {
+	client *redis.Client
+}
+
+// NewOTPAPIRepository constructs a Redis-backed implementation of the public
+// OTP-as-a-service repository contract.
+func NewOTPAPIRepository(client *redis.Client) otp.Repository {
+	return &redisOTPAPIRepository{client: client}
+}
+
+func (r *redisOTPAPIRepository) key(requestID string) string {
+	return otpAPIPrefix + requestID
+}
+
+func (r *redisOTPAPIRepository) rlKey(appID, recipient string) string {
+	return fmt.Sprintf("%s%s:%s", otpRecipientRLPrefix, appID, recipient)
+}
+
+func (r *redisOTPAPIRepository) Create(ctx context.Context, req *otp.Request) error {
+	if req == nil || req.RequestID == "" {
+		return fmt.Errorf("otp repo: request_id required")
+	}
+	ttl := time.Until(req.ExpiresAt)
+	if ttl <= 0 {
+		return fmt.Errorf("otp repo: expires_at must be in the future")
+	}
+	data, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("otp repo: marshal: %w", err)
+	}
+	if err := r.client.Set(ctx, r.key(req.RequestID), data, ttl).Err(); err != nil {
+		return fmt.Errorf("otp repo: set: %w", err)
+	}
+	return nil
+}
+
+func (r *redisOTPAPIRepository) Get(ctx context.Context, requestID string) (*otp.Request, error) {
+	data, err := r.client.Get(ctx, r.key(requestID)).Bytes()
+	if err == redis.Nil {
+		return nil, otp.ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("otp repo: get: %w", err)
+	}
+	var req otp.Request
+	if err := json.Unmarshal(data, &req); err != nil {
+		return nil, fmt.Errorf("otp repo: unmarshal: %w", err)
+	}
+	return &req, nil
+}
+
+// IncrementAttempts atomically increments the attempt counter inside the
+// persisted record. We re-read, mutate, and write inside an optimistic loop —
+// Redis-side WATCH/MULTI is overkill here because each OTP request has its
+// own key and contention is bounded to one logical caller per request_id.
+func (r *redisOTPAPIRepository) IncrementAttempts(ctx context.Context, requestID string) (int, error) {
+	key := r.key(requestID)
+	for attempt := 0; attempt < 5; attempt++ {
+		err := r.client.Watch(ctx, func(tx *redis.Tx) error {
+			data, err := tx.Get(ctx, key).Bytes()
+			if err == redis.Nil {
+				return otp.ErrNotFound
+			}
+			if err != nil {
+				return err
+			}
+			var req otp.Request
+			if err := json.Unmarshal(data, &req); err != nil {
+				return fmt.Errorf("otp repo: unmarshal: %w", err)
+			}
+			req.Attempts++
+			updated, err := json.Marshal(&req)
+			if err != nil {
+				return err
+			}
+			ttl := time.Until(req.ExpiresAt)
+			if ttl <= 0 {
+				return otp.ErrExpired
+			}
+			_, err = tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+				return pipe.Set(ctx, key, updated, ttl).Err()
+			})
+			if err != nil {
+				return err
+			}
+			return nil
+		}, key)
+		if err == nil {
+			// Re-read to return the canonical post-increment count. A second
+			// reader could have incremented in the meantime but for the
+			// "attempts remaining" UX hint this is good enough.
+			cur, getErr := r.Get(ctx, requestID)
+			if getErr != nil {
+				return 0, getErr
+			}
+			return cur.Attempts, nil
+		}
+		if err == redis.TxFailedErr {
+			continue
+		}
+		return 0, err
+	}
+	return 0, fmt.Errorf("otp repo: increment attempts exhausted retries")
+}
+
+func (r *redisOTPAPIRepository) MarkVerified(ctx context.Context, requestID string, verifiedAt time.Time) error {
+	cur, err := r.Get(ctx, requestID)
+	if err != nil {
+		return err
+	}
+	cur.Verified = true
+	cur.VerifiedAt = &verifiedAt
+	return r.Update(ctx, cur)
+}
+
+func (r *redisOTPAPIRepository) Update(ctx context.Context, req *otp.Request) error {
+	if req == nil || req.RequestID == "" {
+		return fmt.Errorf("otp repo: request_id required")
+	}
+	ttl := time.Until(req.ExpiresAt)
+	if ttl <= 0 {
+		// Verified records are still useful briefly for idempotent verify
+		// responses; cap at 60s so they don't linger.
+		ttl = 60 * time.Second
+	}
+	data, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("otp repo: marshal: %w", err)
+	}
+	return r.client.Set(ctx, r.key(req.RequestID), data, ttl).Err()
+}
+
+func (r *redisOTPAPIRepository) Delete(ctx context.Context, requestID string) error {
+	return r.client.Del(ctx, r.key(requestID)).Err()
+}
+
+// RecipientRateLimit uses a rolling sliding-window counter via Redis INCR with
+// a per-window expiry. Counting is approximate (fixed-window) which is fine
+// for OTP abuse-prevention.
+func (r *redisOTPAPIRepository) RecipientRateLimit(ctx context.Context, appID, recipient string, windowSeconds int) (int, error) {
+	if windowSeconds <= 0 {
+		windowSeconds = 3600
+	}
+	key := r.rlKey(appID, recipient)
+	count, err := r.client.Incr(ctx, key).Result()
+	if err != nil {
+		return 0, fmt.Errorf("otp repo: rl incr: %w", err)
+	}
+	if count == 1 {
+		// First hit in window — set the expiry. A failed Expire here is not
+		// fatal; the key will just persist until the next INCR sets it.
+		if err := r.client.Expire(ctx, key, time.Duration(windowSeconds)*time.Second).Err(); err != nil {
+			return int(count), fmt.Errorf("otp repo: rl expire: %w", err)
+		}
+	}
+	return int(count), nil
+}

--- a/internal/interfaces/http/dto/otp_dto.go
+++ b/internal/interfaces/http/dto/otp_dto.go
@@ -1,0 +1,54 @@
+package dto
+
+// OTPSendRequest is the POST /v1/otp/send payload. AppID is taken from the
+// authenticated API key (Locals), not the body.
+//
+// Recipient targeting: provide EXACTLY ONE of `recipient`, `user_id`, or
+// `external_id`. When `user_id` or `external_id` is supplied, the channel
+// address (email or phone) is read from the user record stored in FRN.
+type OTPSendRequest struct {
+	Channel      string                 `json:"channel" validate:"required,oneof=sms whatsapp email"`
+	Recipient    string                 `json:"recipient,omitempty"`     // raw email / E.164 phone
+	UserID       string                 `json:"user_id,omitempty"`       // internal FRN user_id (UUID)
+	ExternalID   string                 `json:"external_id,omitempty"`   // caller-owned user identifier
+	Length       int                    `json:"length,omitempty"`        // 4-10, default 6
+	Alphanumeric bool                   `json:"alphanumeric,omitempty"`  // default false (numeric)
+	TTLSeconds   int                    `json:"ttl_seconds,omitempty"`   // 30-900, default 300
+	MaxAttempts  int                    `json:"max_attempts,omitempty"`  // 1-10, default 5
+	TemplateBody string                 `json:"template_body,omitempty"` // optional BYO body with {{code}}
+	TemplateData map[string]interface{} `json:"template_data,omitempty"`
+}
+
+// OTPSendResponse is returned for both /v1/otp/send and /v1/otp/resend. The
+// notification_id correlates with the underlying notification record for
+// audit and delivery-status lookups. The plaintext code is never returned.
+type OTPSendResponse struct {
+	RequestID      string `json:"request_id"`
+	NotificationID string `json:"notification_id"`
+	Channel        string `json:"channel"`
+	ExpiresAt      string `json:"expires_at"`
+	TTLSeconds     int    `json:"ttl_seconds"`
+	MaxAttempts    int    `json:"max_attempts"`
+}
+
+// OTPVerifyRequest is the POST /v1/otp/verify payload.
+type OTPVerifyRequest struct {
+	RequestID string `json:"request_id" validate:"required"`
+	Code      string `json:"code" validate:"required,min=4,max=10"`
+}
+
+// OTPVerifyResponse is the verify outcome. On failure, Error carries a
+// machine-readable code (e.g. "invalid_code", "expired", "attempts_exhausted")
+// and AttemptsRemaining tells the caller how many tries are left.
+type OTPVerifyResponse struct {
+	Verified          bool   `json:"verified"`
+	RequestID         string `json:"request_id"`
+	VerifiedAt        string `json:"verified_at,omitempty"`
+	AttemptsRemaining int    `json:"attempts_remaining,omitempty"`
+	Error             string `json:"error,omitempty"`
+}
+
+// OTPResendRequest is the POST /v1/otp/resend payload.
+type OTPResendRequest struct {
+	RequestID string `json:"request_id" validate:"required"`
+}

--- a/internal/interfaces/http/handlers/otp_handler.go
+++ b/internal/interfaces/http/handlers/otp_handler.go
@@ -1,0 +1,224 @@
+package handlers
+
+import (
+	"errors"
+
+	"github.com/gofiber/fiber/v2"
+	"go.uber.org/zap"
+
+	"github.com/the-monkeys/freerangenotify/internal/domain/otp"
+	"github.com/the-monkeys/freerangenotify/internal/interfaces/http/dto"
+	"github.com/the-monkeys/freerangenotify/pkg/validator"
+)
+
+// OTPHandler exposes the public OTP-as-a-service endpoints under /v1/otp/*.
+// AppID is sourced from the API-key middleware (`c.Locals("app_id")`), never
+// from the request body, so callers cannot send on behalf of another tenant.
+type OTPHandler struct {
+	service   otp.Service
+	validator *validator.Validator
+	logger    *zap.Logger
+}
+
+// NewOTPHandler constructs an OTPHandler.
+func NewOTPHandler(service otp.Service, v *validator.Validator, logger *zap.Logger) *OTPHandler {
+	return &OTPHandler{service: service, validator: v, logger: logger}
+}
+
+// Send handles POST /v1/otp/send.
+// @Summary Send an OTP
+// @Description Generates a one-time passcode and dispatches it through SMS, WhatsApp, or email via the standard notification pipeline. Subject to standard per-channel credit billing.
+// @Tags OTP
+// @Accept json
+// @Produce json
+// @Param body body dto.OTPSendRequest true "OTP send request"
+// @Success 202 {object} dto.OTPSendResponse
+// @Failure 400 {object} map[string]interface{}
+// @Failure 401 {object} map[string]interface{}
+// @Failure 429 {object} map[string]interface{}
+// @Failure 500 {object} map[string]interface{}
+// @Security ApiKeyAuth
+// @Router /v1/otp/send [post]
+func (h *OTPHandler) Send(c *fiber.Ctx) error {
+	appID, ok := c.Locals("app_id").(string)
+	if !ok || appID == "" {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "application not authenticated"})
+	}
+
+	var req dto.OTPSendRequest
+	if err := c.BodyParser(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid request body"})
+	}
+	if err := h.validator.Validate(req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": err.Error()})
+	}
+
+	res, err := h.service.Send(c.Context(), otp.SendInput{
+		AppID:        appID,
+		Channel:      otp.Channel(req.Channel),
+		Recipient:    req.Recipient,
+		UserID:       req.UserID,
+		ExternalID:   req.ExternalID,
+		Length:       req.Length,
+		Alphanumeric: req.Alphanumeric,
+		TTLSeconds:   req.TTLSeconds,
+		MaxAttempts:  req.MaxAttempts,
+		TemplateBody: req.TemplateBody,
+		TemplateData: req.TemplateData,
+	})
+	if err != nil {
+		return h.writeSendError(c, appID, err)
+	}
+
+	return c.Status(fiber.StatusAccepted).JSON(toSendResponse(res))
+}
+
+// Verify handles POST /v1/otp/verify.
+// @Summary Verify an OTP
+// @Description Verifies a code against a previously-issued request_id. Uses constant-time comparison and atomic attempt counting.
+// @Tags OTP
+// @Accept json
+// @Produce json
+// @Param body body dto.OTPVerifyRequest true "OTP verify request"
+// @Success 200 {object} dto.OTPVerifyResponse
+// @Failure 400 {object} dto.OTPVerifyResponse
+// @Failure 401 {object} map[string]interface{}
+// @Failure 404 {object} dto.OTPVerifyResponse
+// @Failure 410 {object} dto.OTPVerifyResponse
+// @Security ApiKeyAuth
+// @Router /v1/otp/verify [post]
+func (h *OTPHandler) Verify(c *fiber.Ctx) error {
+	if _, ok := c.Locals("app_id").(string); !ok {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "application not authenticated"})
+	}
+
+	var req dto.OTPVerifyRequest
+	if err := c.BodyParser(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid request body"})
+	}
+	if err := h.validator.Validate(req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": err.Error()})
+	}
+
+	res, err := h.service.Verify(c.Context(), otp.VerifyInput{
+		RequestID: req.RequestID,
+		Code:      req.Code,
+	})
+	return h.writeVerifyOutcome(c, req.RequestID, res, err)
+}
+
+// Resend handles POST /v1/otp/resend.
+// @Summary Resend an OTP
+// @Description Re-issues a new code for an existing request_id (subject to 60s cooldown). The previous code is invalidated and attempt counter is reset.
+// @Tags OTP
+// @Accept json
+// @Produce json
+// @Param body body dto.OTPResendRequest true "OTP resend request"
+// @Success 202 {object} dto.OTPSendResponse
+// @Failure 400 {object} map[string]interface{}
+// @Failure 401 {object} map[string]interface{}
+// @Failure 404 {object} map[string]interface{}
+// @Failure 409 {object} map[string]interface{}
+// @Failure 429 {object} map[string]interface{}
+// @Security ApiKeyAuth
+// @Router /v1/otp/resend [post]
+func (h *OTPHandler) Resend(c *fiber.Ctx) error {
+	appID, ok := c.Locals("app_id").(string)
+	if !ok || appID == "" {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "application not authenticated"})
+	}
+
+	var req dto.OTPResendRequest
+	if err := c.BodyParser(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid request body"})
+	}
+	if err := h.validator.Validate(req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": err.Error()})
+	}
+
+	res, err := h.service.Resend(c.Context(), req.RequestID)
+	if err != nil {
+		return h.writeSendError(c, appID, err)
+	}
+	return c.Status(fiber.StatusAccepted).JSON(toSendResponse(res))
+}
+
+// writeSendError centralises the OTP send/resend error→status mapping so the
+// two handlers stay consistent. The HTTP status reflects the semantics:
+//   - 404 for missing request
+//   - 410 for expired
+//   - 409 for already-verified or cooldown
+//   - 429 for rate limit
+//   - 400 for validation / invalid recipient
+func (h *OTPHandler) writeSendError(c *fiber.Ctx, appID string, err error) error {
+	switch {
+	case errors.Is(err, otp.ErrNotFound):
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": err.Error()})
+	case errors.Is(err, otp.ErrExpired):
+		return c.Status(fiber.StatusGone).JSON(fiber.Map{"error": err.Error()})
+	case errors.Is(err, otp.ErrAlreadyVerified), errors.Is(err, otp.ErrResendCooldown):
+		return c.Status(fiber.StatusConflict).JSON(fiber.Map{"error": err.Error()})
+	case errors.Is(err, otp.ErrRateLimited):
+		return c.Status(fiber.StatusTooManyRequests).JSON(fiber.Map{"error": err.Error()})
+	case errors.Is(err, otp.ErrInvalidChannel),
+		errors.Is(err, otp.ErrInvalidRecipient),
+		errors.Is(err, otp.ErrInvalidLength),
+		errors.Is(err, otp.ErrInvalidTTL),
+		errors.Is(err, otp.ErrInvalidAttempts),
+		errors.Is(err, otp.ErrTemplateMissingCode),
+		errors.Is(err, otp.ErrAmbiguousRecipient),
+		errors.Is(err, otp.ErrUserMissingChannelAddress):
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": err.Error()})
+	case errors.Is(err, otp.ErrUserNotFound):
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": err.Error()})
+	}
+	h.logger.Error("OTP send failed", zap.String("app_id", appID), zap.Error(err))
+	return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+}
+
+func (h *OTPHandler) writeVerifyOutcome(c *fiber.Ctx, requestID string, res *otp.VerifyResult, err error) error {
+	if err == nil {
+		out := dto.OTPVerifyResponse{
+			Verified:          res.Verified,
+			RequestID:         requestID,
+			AttemptsRemaining: res.AttemptsRemaining,
+		}
+		if res.VerifiedAt != nil {
+			out.VerifiedAt = res.VerifiedAt.UTC().Format("2006-01-02T15:04:05Z07:00")
+		}
+		return c.Status(fiber.StatusOK).JSON(out)
+	}
+
+	resp := dto.OTPVerifyResponse{Verified: false, RequestID: requestID}
+	switch {
+	case errors.Is(err, otp.ErrInvalidCode):
+		resp.Error = "invalid_code"
+		if res != nil {
+			resp.AttemptsRemaining = res.AttemptsRemaining
+		}
+		return c.Status(fiber.StatusBadRequest).JSON(resp)
+	case errors.Is(err, otp.ErrAttemptsExhausted):
+		resp.Error = "attempts_exhausted"
+		return c.Status(fiber.StatusBadRequest).JSON(resp)
+	case errors.Is(err, otp.ErrExpired):
+		resp.Error = "expired"
+		return c.Status(fiber.StatusGone).JSON(resp)
+	case errors.Is(err, otp.ErrNotFound):
+		resp.Error = "not_found"
+		return c.Status(fiber.StatusNotFound).JSON(resp)
+	}
+	h.logger.Error("OTP verify failed", zap.String("request_id", requestID), zap.Error(err))
+	resp.Error = "internal_error"
+	return c.Status(fiber.StatusInternalServerError).JSON(resp)
+}
+
+func toSendResponse(r *otp.SendResult) dto.OTPSendResponse {
+	return dto.OTPSendResponse{
+		RequestID:      r.RequestID,
+		NotificationID: r.NotificationID,
+		Channel:        string(r.Channel),
+		ExpiresAt:      r.ExpiresAt.UTC().Format("2006-01-02T15:04:05Z07:00"),
+		TTLSeconds:     r.TTLSeconds,
+		MaxAttempts:    r.MaxAttempts,
+	}
+}

--- a/internal/interfaces/http/handlers/otp_handler_test.go
+++ b/internal/interfaces/http/handlers/otp_handler_test.go
@@ -1,0 +1,368 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/the-monkeys/freerangenotify/internal/domain/otp"
+	"github.com/the-monkeys/freerangenotify/pkg/validator"
+)
+
+// ─── stub OTP service ──────────────────────────────────────────────────────
+
+type stubOTPService struct {
+	sendResult   *otp.SendResult
+	sendErr      error
+	verifyResult *otp.VerifyResult
+	verifyErr    error
+	resendResult *otp.SendResult
+	resendErr    error
+
+	lastSendInput   otp.SendInput
+	lastVerifyInput otp.VerifyInput
+	lastResendID    string
+}
+
+var _ otp.Service = (*stubOTPService)(nil)
+
+func (s *stubOTPService) Send(_ context.Context, in otp.SendInput) (*otp.SendResult, error) {
+	s.lastSendInput = in
+	return s.sendResult, s.sendErr
+}
+func (s *stubOTPService) Verify(_ context.Context, in otp.VerifyInput) (*otp.VerifyResult, error) {
+	s.lastVerifyInput = in
+	return s.verifyResult, s.verifyErr
+}
+func (s *stubOTPService) Resend(_ context.Context, id string) (*otp.SendResult, error) {
+	s.lastResendID = id
+	return s.resendResult, s.resendErr
+}
+
+// ─── test app helper ────────────────────────────────────────────────────────
+
+func setupOTPApp(t *testing.T, svc *stubOTPService, appID string) *fiber.App {
+	t.Helper()
+	logger := zaptest.NewLogger(t)
+	h := NewOTPHandler(svc, validator.New(), logger)
+
+	app := fiber.New()
+	if appID != "" {
+		app.Use(func(c *fiber.Ctx) error {
+			c.Locals("app_id", appID)
+			return c.Next()
+		})
+	}
+	app.Post("/v1/otp/send", h.Send)
+	app.Post("/v1/otp/verify", h.Verify)
+	app.Post("/v1/otp/resend", h.Resend)
+	return app
+}
+
+func doOTPRequest(t *testing.T, app *fiber.App, method, path string, body interface{}) (*http.Response, map[string]interface{}) {
+	t.Helper()
+	var payload []byte
+	if s, ok := body.(string); ok {
+		payload = []byte(s)
+	} else {
+		payload, _ = json.Marshal(body)
+	}
+	req := httptest.NewRequest(method, path, bytes.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req, 5000)
+	require.NoError(t, err)
+	var out map[string]interface{}
+	_ = json.NewDecoder(resp.Body).Decode(&out)
+	resp.Body.Close()
+	return resp, out
+}
+
+// ─── Send ──────────────────────────────────────────────────────────────────
+
+func TestOTPHandler_Send_Success(t *testing.T) {
+	expires := time.Now().Add(5 * time.Minute)
+	svc := &stubOTPService{
+		sendResult: &otp.SendResult{
+			RequestID:      "req-1",
+			NotificationID: "notif-1",
+			Channel:        otp.ChannelSMS,
+			ExpiresAt:      expires,
+			TTLSeconds:     300,
+			MaxAttempts:    5,
+		},
+	}
+	app := setupOTPApp(t, svc, "app-1")
+
+	resp, body := doOTPRequest(t, app, http.MethodPost, "/v1/otp/send", map[string]interface{}{
+		"channel":   "sms",
+		"recipient": "+14155551212",
+	})
+
+	assert.Equal(t, http.StatusAccepted, resp.StatusCode)
+	assert.Equal(t, "req-1", body["request_id"])
+	assert.Equal(t, "notif-1", body["notification_id"])
+	assert.Equal(t, "sms", body["channel"])
+	assert.Equal(t, "app-1", svc.lastSendInput.AppID)
+	assert.Equal(t, otp.ChannelSMS, svc.lastSendInput.Channel)
+	assert.Equal(t, "+14155551212", svc.lastSendInput.Recipient)
+}
+
+func TestOTPHandler_Send_MissingAppID_Returns401(t *testing.T) {
+	svc := &stubOTPService{}
+	app := setupOTPApp(t, svc, "") // no middleware
+
+	resp, _ := doOTPRequest(t, app, http.MethodPost, "/v1/otp/send", map[string]interface{}{
+		"channel":   "sms",
+		"recipient": "+14155551212",
+	})
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+func TestOTPHandler_Send_BadJSON_Returns400(t *testing.T) {
+	svc := &stubOTPService{}
+	app := setupOTPApp(t, svc, "app-1")
+	resp, _ := doOTPRequest(t, app, http.MethodPost, "/v1/otp/send", "{not-json")
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestOTPHandler_Send_ValidationFails_Returns400(t *testing.T) {
+	svc := &stubOTPService{}
+	app := setupOTPApp(t, svc, "app-1")
+	// missing required `channel` + `recipient`
+	resp, _ := doOTPRequest(t, app, http.MethodPost, "/v1/otp/send", map[string]interface{}{})
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestOTPHandler_Send_ErrorMapping(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		code int
+	}{
+		{"not_found", otp.ErrNotFound, http.StatusNotFound},
+		{"expired", otp.ErrExpired, http.StatusGone},
+		{"already_verified", otp.ErrAlreadyVerified, http.StatusConflict},
+		{"resend_cooldown", otp.ErrResendCooldown, http.StatusConflict},
+		{"rate_limited", otp.ErrRateLimited, http.StatusTooManyRequests},
+		{"invalid_channel", otp.ErrInvalidChannel, http.StatusBadRequest},
+		{"invalid_recipient", otp.ErrInvalidRecipient, http.StatusBadRequest},
+		{"invalid_length", otp.ErrInvalidLength, http.StatusBadRequest},
+		{"invalid_ttl", otp.ErrInvalidTTL, http.StatusBadRequest},
+		{"invalid_attempts", otp.ErrInvalidAttempts, http.StatusBadRequest},
+		{"template_missing_code", otp.ErrTemplateMissingCode, http.StatusBadRequest},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := &stubOTPService{sendErr: tc.err}
+			app := setupOTPApp(t, svc, "app-1")
+			resp, _ := doOTPRequest(t, app, http.MethodPost, "/v1/otp/send", map[string]interface{}{
+				"channel":   "sms",
+				"recipient": "+14155551212",
+			})
+			assert.Equal(t, tc.code, resp.StatusCode)
+		})
+	}
+}
+
+func TestOTPHandler_Send_UnknownError_Returns500(t *testing.T) {
+	svc := &stubOTPService{sendErr: assertAnyError{}}
+	app := setupOTPApp(t, svc, "app-1")
+	resp, _ := doOTPRequest(t, app, http.MethodPost, "/v1/otp/send", map[string]interface{}{
+		"channel":   "sms",
+		"recipient": "+14155551212",
+	})
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+}
+
+// ─── Verify ────────────────────────────────────────────────────────────────
+
+func TestOTPHandler_Verify_Success(t *testing.T) {
+	now := time.Now().UTC()
+	svc := &stubOTPService{
+		verifyResult: &otp.VerifyResult{Verified: true, VerifiedAt: &now},
+	}
+	app := setupOTPApp(t, svc, "app-1")
+
+	resp, body := doOTPRequest(t, app, http.MethodPost, "/v1/otp/verify", map[string]interface{}{
+		"request_id": "req-1",
+		"code":       "123456",
+	})
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, true, body["verified"])
+	assert.Equal(t, "req-1", body["request_id"])
+	assert.NotEmpty(t, body["verified_at"])
+	assert.Equal(t, "req-1", svc.lastVerifyInput.RequestID)
+	assert.Equal(t, "123456", svc.lastVerifyInput.Code)
+}
+
+func TestOTPHandler_Verify_MissingAppID_Returns401(t *testing.T) {
+	svc := &stubOTPService{}
+	app := setupOTPApp(t, svc, "")
+	resp, _ := doOTPRequest(t, app, http.MethodPost, "/v1/otp/verify", map[string]interface{}{
+		"request_id": "req-1",
+		"code":       "123456",
+	})
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+func TestOTPHandler_Verify_BadJSON_Returns400(t *testing.T) {
+	svc := &stubOTPService{}
+	app := setupOTPApp(t, svc, "app-1")
+	resp, _ := doOTPRequest(t, app, http.MethodPost, "/v1/otp/verify", "{bad")
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestOTPHandler_Verify_ValidationFails_Returns400(t *testing.T) {
+	svc := &stubOTPService{}
+	app := setupOTPApp(t, svc, "app-1")
+	// missing both fields
+	resp, _ := doOTPRequest(t, app, http.MethodPost, "/v1/otp/verify", map[string]interface{}{})
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestOTPHandler_Verify_InvalidCode(t *testing.T) {
+	svc := &stubOTPService{
+		verifyResult: &otp.VerifyResult{Verified: false, AttemptsRemaining: 3},
+		verifyErr:    otp.ErrInvalidCode,
+	}
+	app := setupOTPApp(t, svc, "app-1")
+	resp, body := doOTPRequest(t, app, http.MethodPost, "/v1/otp/verify", map[string]interface{}{
+		"request_id": "req-1",
+		"code":       "000000",
+	})
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, false, body["verified"])
+	assert.Equal(t, "invalid_code", body["error"])
+	assert.Equal(t, float64(3), body["attempts_remaining"])
+}
+
+func TestOTPHandler_Verify_AttemptsExhausted(t *testing.T) {
+	svc := &stubOTPService{verifyErr: otp.ErrAttemptsExhausted}
+	app := setupOTPApp(t, svc, "app-1")
+	resp, body := doOTPRequest(t, app, http.MethodPost, "/v1/otp/verify", map[string]interface{}{
+		"request_id": "req-1",
+		"code":       "000000",
+	})
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, "attempts_exhausted", body["error"])
+}
+
+func TestOTPHandler_Verify_Expired(t *testing.T) {
+	svc := &stubOTPService{verifyErr: otp.ErrExpired}
+	app := setupOTPApp(t, svc, "app-1")
+	resp, body := doOTPRequest(t, app, http.MethodPost, "/v1/otp/verify", map[string]interface{}{
+		"request_id": "req-1",
+		"code":       "123456",
+	})
+	assert.Equal(t, http.StatusGone, resp.StatusCode)
+	assert.Equal(t, "expired", body["error"])
+}
+
+func TestOTPHandler_Verify_NotFound(t *testing.T) {
+	svc := &stubOTPService{verifyErr: otp.ErrNotFound}
+	app := setupOTPApp(t, svc, "app-1")
+	resp, body := doOTPRequest(t, app, http.MethodPost, "/v1/otp/verify", map[string]interface{}{
+		"request_id": "req-missing",
+		"code":       "123456",
+	})
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	assert.Equal(t, "not_found", body["error"])
+}
+
+func TestOTPHandler_Verify_UnknownError_Returns500(t *testing.T) {
+	svc := &stubOTPService{verifyErr: assertAnyError{}}
+	app := setupOTPApp(t, svc, "app-1")
+	resp, body := doOTPRequest(t, app, http.MethodPost, "/v1/otp/verify", map[string]interface{}{
+		"request_id": "req-1",
+		"code":       "123456",
+	})
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	assert.Equal(t, "internal_error", body["error"])
+}
+
+// ─── Resend ────────────────────────────────────────────────────────────────
+
+func TestOTPHandler_Resend_Success(t *testing.T) {
+	svc := &stubOTPService{
+		resendResult: &otp.SendResult{
+			RequestID:      "req-1",
+			NotificationID: "notif-2",
+			Channel:        otp.ChannelEmail,
+			ExpiresAt:      time.Now().Add(5 * time.Minute),
+			TTLSeconds:     300,
+			MaxAttempts:    5,
+		},
+	}
+	app := setupOTPApp(t, svc, "app-1")
+	resp, body := doOTPRequest(t, app, http.MethodPost, "/v1/otp/resend", map[string]interface{}{
+		"request_id": "req-1",
+	})
+	assert.Equal(t, http.StatusAccepted, resp.StatusCode)
+	assert.Equal(t, "req-1", body["request_id"])
+	assert.Equal(t, "notif-2", body["notification_id"])
+	assert.Equal(t, "req-1", svc.lastResendID)
+}
+
+func TestOTPHandler_Resend_MissingAppID_Returns401(t *testing.T) {
+	svc := &stubOTPService{}
+	app := setupOTPApp(t, svc, "")
+	resp, _ := doOTPRequest(t, app, http.MethodPost, "/v1/otp/resend", map[string]interface{}{
+		"request_id": "req-1",
+	})
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+func TestOTPHandler_Resend_BadJSON_Returns400(t *testing.T) {
+	svc := &stubOTPService{}
+	app := setupOTPApp(t, svc, "app-1")
+	resp, _ := doOTPRequest(t, app, http.MethodPost, "/v1/otp/resend", "{")
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestOTPHandler_Resend_ValidationFails_Returns400(t *testing.T) {
+	svc := &stubOTPService{}
+	app := setupOTPApp(t, svc, "app-1")
+	resp, _ := doOTPRequest(t, app, http.MethodPost, "/v1/otp/resend", map[string]interface{}{})
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestOTPHandler_Resend_ErrorMapping(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		code int
+	}{
+		{"not_found", otp.ErrNotFound, http.StatusNotFound},
+		{"already_verified", otp.ErrAlreadyVerified, http.StatusConflict},
+		{"cooldown", otp.ErrResendCooldown, http.StatusConflict},
+		{"rate_limited", otp.ErrRateLimited, http.StatusTooManyRequests},
+		{"expired", otp.ErrExpired, http.StatusGone},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := &stubOTPService{resendErr: tc.err}
+			app := setupOTPApp(t, svc, "app-1")
+			resp, _ := doOTPRequest(t, app, http.MethodPost, "/v1/otp/resend", map[string]interface{}{
+				"request_id": "req-1",
+			})
+			assert.Equal(t, tc.code, resp.StatusCode)
+		})
+	}
+}
+
+// ─── helpers ───────────────────────────────────────────────────────────────
+
+// assertAnyError is a sentinel error type that does NOT match any of the
+// otp.Err* sentinels, used to exercise the default 500 branch.
+type assertAnyError struct{}
+
+func (assertAnyError) Error() string { return "boom" }

--- a/internal/interfaces/http/routes/routes.go
+++ b/internal/interfaces/http/routes/routes.go
@@ -169,6 +169,17 @@ func setupProtectedRoutes(v1 fiber.Router, c *container.Container) {
 	// Quick-send (simplified notification endpoint)
 	v1.Post("/quick-send", apiAuth, licenseCheck, c.QuickSendHandler.Send)
 
+	// OTP-as-a-service: send, verify, and resend one-time codes via SMS,
+	// WhatsApp, or email. Send/resend pass through licenseCheck because they
+	// consume credits via the underlying notification pipeline; verify is a
+	// pure Redis read and is exempt.
+	if c.OTPHandler != nil {
+		otpGrp := v1.Group("/otp", apiAuth)
+		otpGrp.Post("/send", licenseCheck, c.OTPHandler.Send)
+		otpGrp.Post("/verify", c.OTPHandler.Verify)
+		otpGrp.Post("/resend", licenseCheck, c.OTPHandler.Resend)
+	}
+
 	// Media upload (for WhatsApp file attachments)
 	v1.Post("/media/upload", apiAuth, c.MediaHandler.Upload)
 

--- a/internal/usecases/services/otp_service.go
+++ b/internal/usecases/services/otp_service.go
@@ -1,0 +1,668 @@
+package services
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"net/mail"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"github.com/the-monkeys/freerangenotify/internal/domain/notification"
+	"github.com/the-monkeys/freerangenotify/internal/domain/otp"
+	templateDomain "github.com/the-monkeys/freerangenotify/internal/domain/template"
+	"github.com/the-monkeys/freerangenotify/internal/domain/user"
+)
+
+// notificationSender is the narrow slice of notification.Service that the
+// OTP service depends on. Keeping it minimal lets tests substitute a stub
+// without implementing every notification.Service method.
+type notificationSender interface {
+	Send(ctx context.Context, req notification.SendRequest) (*notification.Notification, error)
+}
+
+// userResolver is the narrow slice of user.Repository the OTP service uses
+// to look up or auto-create recipient users.
+type userResolver interface {
+	Create(ctx context.Context, u *user.User) error
+	GetByID(ctx context.Context, id string) (*user.User, error)
+	GetByEmail(ctx context.Context, appID, email string) (*user.User, error)
+	GetByExternalID(ctx context.Context, appID, externalID string) (*user.User, error)
+}
+
+// templateCreator is the narrow slice of usecases.TemplateService the OTP
+// service uses to materialise a transient template per send.
+type templateCreator interface {
+	Create(ctx context.Context, req *templateDomain.CreateRequest) (*templateDomain.Template, error)
+}
+
+// OTPService is the public OTP-as-a-service implementation. It generates the
+// verification code, persists a hashed copy in Redis, and dispatches the
+// notification through the standard notification pipeline so that credit
+// metering, audit logging, retries, and provider routing all work without
+// duplication.
+type OTPService struct {
+	repo            otp.Repository
+	notificationSvc notificationSender
+	userRepo        userResolver
+	templateService templateCreator
+	logger          *zap.Logger
+
+	resendCooldownSec   int
+	recipientLimitPerHr int
+}
+
+// NewOTPService constructs a service. resendCooldownSec defaults to 60s and
+// recipientLimitPerHr to 5 when given non-positive values.
+func NewOTPService(
+	repo otp.Repository,
+	notificationSvc notificationSender,
+	userRepo userResolver,
+	templateService templateCreator,
+	logger *zap.Logger,
+) *OTPService {
+	return &OTPService{
+		repo:                repo,
+		notificationSvc:     notificationSvc,
+		userRepo:            userRepo,
+		templateService:     templateService,
+		logger:              logger,
+		resendCooldownSec:   otp.DefaultResendCooldownS,
+		recipientLimitPerHr: 5,
+	}
+}
+
+// e164Re is a permissive E.164 validator: leading +, then 8-15 digits. Strict
+// per-country validation is the caller's responsibility.
+var e164Re = regexp.MustCompile(`^\+[1-9]\d{7,14}$`)
+
+// Send creates a new OTP, dispatches it through the notification pipeline,
+// and persists the hashed record.
+func (s *OTPService) Send(ctx context.Context, in otp.SendInput) (*otp.SendResult, error) {
+	if err := s.validateSendInput(&in); err != nil {
+		return nil, err
+	}
+
+	// Resolve the recipient up-front so rate limiting, persistence, and the
+	// notification dispatch all key off the SAME channel address. When the
+	// caller passes user_id / external_id, the channel-appropriate field on
+	// the user record (email or phone) becomes the canonical Recipient.
+	resolvedUserID, resolvedAddress, err := s.resolveRecipient(ctx, &in)
+	if err != nil {
+		return nil, err
+	}
+	in.Recipient = resolvedAddress
+
+	// Rate-limit per app+recipient (default 5 sends / hour). Hits before any
+	// expensive work so abusive callers don't burn credits or fill Redis.
+	if count, err := s.repo.RecipientRateLimit(ctx, in.AppID, in.Recipient, 3600); err != nil {
+		s.logger.Warn("otp: rate-limit check failed (allowing)", zap.Error(err))
+	} else if count > s.recipientLimitPerHr {
+		return nil, otp.ErrRateLimited
+	}
+
+	// Generate the plaintext code, hash it, and forget the plaintext on
+	// return (we render it once into the notification body below). The code
+	// itself never lands in any log line.
+	code, err := generateCode(in.Length, in.Alphanumeric)
+	if err != nil {
+		return nil, fmt.Errorf("otp: generate code: %w", err)
+	}
+	salt, err := randomHex(16)
+	if err != nil {
+		return nil, fmt.Errorf("otp: generate salt: %w", err)
+	}
+	codeHash := hashCode(code, salt)
+
+	now := time.Now().UTC()
+	ttlSec := in.TTLSeconds
+	if ttlSec == 0 {
+		ttlSec = otp.DefaultTTLSeconds
+	}
+	maxAttempts := in.MaxAttempts
+	if maxAttempts == 0 {
+		maxAttempts = otp.DefaultMaxAttempts
+	}
+
+	req := &otp.Request{
+		RequestID:    "otp_" + strings.ReplaceAll(uuid.NewString(), "-", ""),
+		AppID:        in.AppID,
+		Channel:      in.Channel,
+		Recipient:    in.Recipient,
+		CodeHash:     codeHash,
+		Salt:         salt,
+		Length:       in.Length,
+		Alphanumeric: in.Alphanumeric,
+		Attempts:     0,
+		MaxAttempts:  maxAttempts,
+		ExpiresAt:    now.Add(time.Duration(ttlSec) * time.Second),
+		LastSentAt:   now,
+		CreatedAt:    now,
+	}
+
+	notif, err := s.dispatchNotification(ctx, req, resolvedUserID, code, in.TemplateBody, in.TemplateData)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := s.repo.Create(ctx, req); err != nil {
+		// Code already left the building via the notification pipeline. Best
+		// we can do is log and surface the error so the caller knows verify
+		// will fail.
+		s.logger.Error("otp: persist after dispatch failed",
+			zap.String("request_id", req.RequestID),
+			zap.String("notification_id", notif),
+			zap.Error(err))
+		return nil, fmt.Errorf("otp: persist: %w", err)
+	}
+
+	s.logger.Info("otp: sent",
+		zap.String("request_id", req.RequestID),
+		zap.String("notification_id", notif),
+		zap.String("channel", string(req.Channel)),
+		zap.Int("ttl_seconds", ttlSec),
+		zap.Int("max_attempts", maxAttempts),
+		// recipient is intentionally NOT logged at info level — it's PII.
+	)
+
+	return &otp.SendResult{
+		RequestID:      req.RequestID,
+		NotificationID: notif,
+		Channel:        req.Channel,
+		ExpiresAt:      req.ExpiresAt,
+		TTLSeconds:     ttlSec,
+		MaxAttempts:    maxAttempts,
+	}, nil
+}
+
+// Verify checks a code against the stored hash with attempt counting and
+// constant-time comparison. Idempotent: a second successful verify for an
+// already-verified request returns success without re-incrementing attempts.
+func (s *OTPService) Verify(ctx context.Context, in otp.VerifyInput) (*otp.VerifyResult, error) {
+	requestID := strings.TrimSpace(in.RequestID)
+	code := strings.TrimSpace(in.Code)
+	if requestID == "" || code == "" {
+		return nil, otp.ErrInvalidCode
+	}
+
+	req, err := s.repo.Get(ctx, requestID)
+	if err != nil {
+		return nil, err
+	}
+	if time.Now().UTC().After(req.ExpiresAt) {
+		return nil, otp.ErrExpired
+	}
+
+	if req.Verified {
+		// Idempotent: return prior success without consuming an attempt.
+		return &otp.VerifyResult{
+			Verified:          true,
+			AttemptsRemaining: req.MaxAttempts - req.Attempts,
+			VerifiedAt:        req.VerifiedAt,
+		}, nil
+	}
+
+	// Atomically increment first — this prevents brute-force races where
+	// concurrent verifies would otherwise share a single attempt budget.
+	attempts, err := s.repo.IncrementAttempts(ctx, requestID)
+	if err != nil {
+		return nil, err
+	}
+	if attempts > req.MaxAttempts {
+		// Burn the record on exhaustion so the same request_id cannot be
+		// retried after recovering somehow.
+		_ = s.repo.Delete(ctx, requestID)
+		return nil, otp.ErrAttemptsExhausted
+	}
+
+	expectedHash, err := hex.DecodeString(req.CodeHash)
+	if err != nil {
+		return nil, fmt.Errorf("otp: corrupt hash: %w", err)
+	}
+	actualHash := sha256.Sum256([]byte(code + req.Salt))
+
+	if subtle.ConstantTimeCompare(expectedHash, actualHash[:]) != 1 {
+		return &otp.VerifyResult{
+			Verified:          false,
+			AttemptsRemaining: req.MaxAttempts - attempts,
+		}, otp.ErrInvalidCode
+	}
+
+	now := time.Now().UTC()
+	if err := s.repo.MarkVerified(ctx, requestID, now); err != nil {
+		s.logger.Error("otp: mark verified failed", zap.String("request_id", requestID), zap.Error(err))
+		return nil, fmt.Errorf("otp: persist verify: %w", err)
+	}
+
+	s.logger.Info("otp: verified",
+		zap.String("request_id", requestID),
+		zap.String("channel", string(req.Channel)),
+	)
+
+	return &otp.VerifyResult{
+		Verified:          true,
+		AttemptsRemaining: req.MaxAttempts - attempts,
+		VerifiedAt:        &now,
+	}, nil
+}
+
+// Resend dispatches the SAME code through a fresh notification. Re-issuing
+// a new code on resend would invalidate any prior delivery and double-charge
+// the customer; instead we reset the attempt counter and re-render.
+func (s *OTPService) Resend(ctx context.Context, requestID string) (*otp.SendResult, error) {
+	requestID = strings.TrimSpace(requestID)
+	if requestID == "" {
+		return nil, otp.ErrNotFound
+	}
+	req, err := s.repo.Get(ctx, requestID)
+	if err != nil {
+		return nil, err
+	}
+	if req.Verified {
+		return nil, otp.ErrAlreadyVerified
+	}
+	if time.Now().UTC().After(req.ExpiresAt) {
+		return nil, otp.ErrExpired
+	}
+	cooldownEnd := req.LastSentAt.Add(time.Duration(s.resendCooldownSec) * time.Second)
+	if time.Now().UTC().Before(cooldownEnd) {
+		return nil, otp.ErrResendCooldown
+	}
+
+	// Resend uses the same code — but the plaintext was discarded after the
+	// initial send. We cannot recover it; the only safe path is to abort.
+	// To support true "resend same code" semantics we would need to keep the
+	// plaintext (or a reversible encryption of it) until expiry, which
+	// materially weakens the security posture. Instead resend mints a fresh
+	// code while preserving the request_id — most providers (Twilio Verify,
+	// Auth0, Firebase) work this way.
+	code, err := generateCode(req.Length, req.Alphanumeric)
+	if err != nil {
+		return nil, fmt.Errorf("otp: generate code: %w", err)
+	}
+	salt, err := randomHex(16)
+	if err != nil {
+		return nil, fmt.Errorf("otp: generate salt: %w", err)
+	}
+	req.CodeHash = hashCode(code, salt)
+	req.Salt = salt
+	req.Attempts = 0
+	req.LastSentAt = time.Now().UTC()
+
+	notifID, err := s.dispatchNotification(ctx, req, "", code, "", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := s.repo.Update(ctx, req); err != nil {
+		s.logger.Error("otp: resend persist failed",
+			zap.String("request_id", req.RequestID),
+			zap.String("notification_id", notifID),
+			zap.Error(err))
+		return nil, fmt.Errorf("otp: persist: %w", err)
+	}
+
+	s.logger.Info("otp: resent",
+		zap.String("request_id", req.RequestID),
+		zap.String("notification_id", notifID),
+		zap.String("channel", string(req.Channel)),
+	)
+
+	return &otp.SendResult{
+		RequestID:      req.RequestID,
+		NotificationID: notifID,
+		Channel:        req.Channel,
+		ExpiresAt:      req.ExpiresAt,
+		TTLSeconds:     int(time.Until(req.ExpiresAt).Seconds()),
+		MaxAttempts:    req.MaxAttempts,
+	}, nil
+}
+
+// resolveRecipient turns the SendInput's identifier triple (recipient /
+// user_id / external_id) into the concrete (userID, channelAddress) pair the
+// rest of the pipeline needs. Exactly one of the three is expected to be
+// populated — that contract is enforced in validateSendInput.
+//
+// When `recipient` is supplied, no lookup happens here; userID is left empty
+// so dispatchNotification will fall through to its legacy auto-create path.
+// When `user_id` or `external_id` is supplied, the user is loaded and the
+// channel-appropriate field (Email for email; Phone for sms/whatsapp) is
+// returned as the recipient.
+func (s *OTPService) resolveRecipient(ctx context.Context, in *otp.SendInput) (userID, address string, err error) {
+	switch {
+	case in.UserID != "":
+		u, lookupErr := s.userRepo.GetByID(ctx, in.UserID)
+		if lookupErr != nil || u == nil {
+			return "", "", otp.ErrUserNotFound
+		}
+		// Tenancy guard: a user_id must belong to the calling app. Without
+		// this check, a leaked user_id from one tenant could be probed
+		// across other tenants' API keys.
+		if u.AppID != in.AppID {
+			return "", "", otp.ErrUserNotFound
+		}
+		addr, addrErr := channelAddressForUser(u, in.Channel)
+		if addrErr != nil {
+			return "", "", addrErr
+		}
+		return u.UserID, addr, nil
+
+	case in.ExternalID != "":
+		u, lookupErr := s.userRepo.GetByExternalID(ctx, in.AppID, in.ExternalID)
+		if lookupErr != nil || u == nil {
+			return "", "", otp.ErrUserNotFound
+		}
+		addr, addrErr := channelAddressForUser(u, in.Channel)
+		if addrErr != nil {
+			return "", "", addrErr
+		}
+		return u.UserID, addr, nil
+
+	default:
+		// Legacy path: caller supplied a raw recipient. Defer user resolution
+		// to dispatchNotification (which auto-creates when missing).
+		return "", in.Recipient, nil
+	}
+}
+
+// channelAddressForUser pulls the contact address from a user record that
+// corresponds to the requested OTP channel.
+func channelAddressForUser(u *user.User, channel otp.Channel) (string, error) {
+	switch channel {
+	case otp.ChannelEmail:
+		if strings.TrimSpace(u.Email) == "" {
+			return "", otp.ErrUserMissingChannelAddress
+		}
+		return u.Email, nil
+	case otp.ChannelSMS, otp.ChannelWhatsApp:
+		if strings.TrimSpace(u.Phone) == "" {
+			return "", otp.ErrUserMissingChannelAddress
+		}
+		return u.Phone, nil
+	}
+	return "", otp.ErrInvalidChannel
+}
+
+// dispatchNotification resolves the recipient to an internal user (auto-
+// creating an ephemeral record when needed), creates a transient template
+// with the rendered OTP body, and delegates to notification.Service.Send.
+// Returns the notification ID. Code plaintext stays scoped to this function.
+//
+// If preResolvedUserID is non-empty, the recipient-lookup step is skipped —
+// this is the path taken when the caller supplied user_id / external_id and
+// Send already resolved the user.
+func (s *OTPService) dispatchNotification(
+	ctx context.Context,
+	req *otp.Request,
+	preResolvedUserID string,
+	code string,
+	customTemplateBody string,
+	templateData map[string]interface{},
+) (string, error) {
+	userID := preResolvedUserID
+	if userID == "" {
+		var err error
+		userID, err = s.resolveOrCreateRecipientUser(ctx, req.AppID, req.Channel, req.Recipient)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	body := renderOTPBody(customTemplateBody, code, int(time.Until(req.ExpiresAt).Minutes()))
+	subject := "Your verification code"
+
+	channelString := channelToNotificationChannel(req.Channel)
+	tmplName := fmt.Sprintf("_otp_%s", uuid.NewString()[:8])
+	tmpl, err := s.templateService.Create(ctx, &templateDomain.CreateRequest{
+		AppID:     req.AppID,
+		Name:      tmplName,
+		Channel:   channelString,
+		Subject:   subject,
+		Body:      body,
+		Locale:    "en",
+		CreatedBy: "system:otp",
+	})
+	if err != nil {
+		return "", fmt.Errorf("otp: create transient template: %w", err)
+	}
+
+	data := map[string]interface{}{}
+	for k, v := range templateData {
+		data[k] = v
+	}
+	// `code` is intentionally exposed to the template renderer so BYO
+	// templates that include {{code}} resolve correctly. Do not place the
+	// raw code into structured fields like Notification.Content.Data that
+	// might be persisted long-term beyond Body rendering.
+	data["code"] = code
+
+	sendReq := notification.SendRequest{
+		AppID:      req.AppID,
+		UserID:     userID,
+		Channel:    notification.Channel(channelString),
+		Priority:   notification.PriorityHigh, // OTPs are time-sensitive
+		TemplateID: tmpl.ID,
+		Data:       data,
+		Metadata: map[string]interface{}{
+			"otp_request_id": req.RequestID,
+		},
+	}
+	notif, err := s.notificationSvc.Send(ctx, sendReq)
+	if err != nil {
+		return "", fmt.Errorf("otp: dispatch notification: %w", err)
+	}
+	return notif.NotificationID, nil
+}
+
+func (s *OTPService) resolveOrCreateRecipientUser(
+	ctx context.Context,
+	appID string,
+	channel otp.Channel,
+	recipient string,
+) (string, error) {
+	true_ := true
+	prefs := user.Preferences{
+		EmailEnabled:    &true_,
+		SMSEnabled:      &true_,
+		WhatsAppEnabled: &true_,
+	}
+
+	// Email path uses the email index for de-dup.
+	if channel == otp.ChannelEmail {
+		existing, err := s.userRepo.GetByEmail(ctx, appID, recipient)
+		if err == nil && existing != nil {
+			return existing.UserID, nil
+		}
+		now := time.Now().UTC()
+		u := &user.User{
+			UserID:      uuid.NewString(),
+			AppID:       appID,
+			Email:       recipient,
+			Preferences: prefs,
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		}
+		if err := s.userRepo.Create(ctx, u); err != nil {
+			return "", fmt.Errorf("otp: auto-create email user: %w", err)
+		}
+		return u.UserID, nil
+	}
+
+	// Phone path (SMS + WhatsApp) — use external_id == E.164 as a stable
+	// de-dup key. The same user is reused across both channels.
+	existing, err := s.userRepo.GetByExternalID(ctx, appID, recipient)
+	if err == nil && existing != nil {
+		return existing.UserID, nil
+	}
+	now := time.Now().UTC()
+	u := &user.User{
+		UserID:      uuid.NewString(),
+		AppID:       appID,
+		ExternalID:  recipient,
+		Phone:       recipient,
+		Preferences: prefs,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	if err := s.userRepo.Create(ctx, u); err != nil {
+		return "", fmt.Errorf("otp: auto-create phone user: %w", err)
+	}
+	return u.UserID, nil
+}
+
+func (s *OTPService) validateSendInput(in *otp.SendInput) error {
+	in.AppID = strings.TrimSpace(in.AppID)
+	in.Recipient = strings.TrimSpace(in.Recipient)
+	in.UserID = strings.TrimSpace(in.UserID)
+	in.ExternalID = strings.TrimSpace(in.ExternalID)
+	if in.AppID == "" {
+		return fmt.Errorf("otp: app_id required")
+	}
+	if !in.Channel.Valid() {
+		return otp.ErrInvalidChannel
+	}
+	// Exactly one of recipient / user_id / external_id must be supplied.
+	supplied := 0
+	if in.Recipient != "" {
+		supplied++
+	}
+	if in.UserID != "" {
+		supplied++
+	}
+	if in.ExternalID != "" {
+		supplied++
+	}
+	switch supplied {
+	case 0:
+		return otp.ErrInvalidRecipient
+	case 1:
+		// ok
+	default:
+		return otp.ErrAmbiguousRecipient
+	}
+	// Format validation only applies to the raw-recipient path; for the
+	// user_id / external_id paths the address is read from a vetted user
+	// record after lookup.
+	if in.Recipient != "" {
+		if err := validateRecipient(in.Channel, in.Recipient); err != nil {
+			return err
+		}
+	}
+	if in.Length == 0 {
+		in.Length = otp.DefaultCodeLength
+	}
+	if in.Length < otp.MinCodeLength || in.Length > otp.MaxCodeLength {
+		return otp.ErrInvalidLength
+	}
+	if in.TTLSeconds == 0 {
+		in.TTLSeconds = otp.DefaultTTLSeconds
+	}
+	if in.TTLSeconds < 30 || in.TTLSeconds > otp.MaxTTLSeconds {
+		return otp.ErrInvalidTTL
+	}
+	if in.MaxAttempts == 0 {
+		in.MaxAttempts = otp.DefaultMaxAttempts
+	}
+	if in.MaxAttempts < otp.MinAttempts || in.MaxAttempts > otp.MaxAttemptsCap {
+		return otp.ErrInvalidAttempts
+	}
+	if in.TemplateBody != "" && !strings.Contains(in.TemplateBody, "{{code}}") &&
+		!strings.Contains(in.TemplateBody, "{{ code }}") &&
+		!strings.Contains(in.TemplateBody, "{{.code}}") {
+		return otp.ErrTemplateMissingCode
+	}
+	return nil
+}
+
+func validateRecipient(channel otp.Channel, recipient string) error {
+	if recipient == "" {
+		return otp.ErrInvalidRecipient
+	}
+	switch channel {
+	case otp.ChannelEmail:
+		if _, err := mail.ParseAddress(recipient); err != nil {
+			return otp.ErrInvalidRecipient
+		}
+	case otp.ChannelSMS, otp.ChannelWhatsApp:
+		if !e164Re.MatchString(recipient) {
+			return otp.ErrInvalidRecipient
+		}
+	}
+	return nil
+}
+
+// generateCode produces a cryptographically secure numeric or alphanumeric
+// code of the given length using crypto/rand. The alphanumeric alphabet
+// excludes look-alike characters (0/O, 1/I/l) to reduce user transcription
+// errors.
+func generateCode(length int, alphanumeric bool) (string, error) {
+	const numeric = "0123456789"
+	const alnum = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789" // no 0,O,1,I,l
+	alphabet := numeric
+	if alphanumeric {
+		alphabet = alnum
+	}
+	mod := big.NewInt(int64(len(alphabet)))
+	out := make([]byte, length)
+	for i := 0; i < length; i++ {
+		n, err := rand.Int(rand.Reader, mod)
+		if err != nil {
+			return "", err
+		}
+		out[i] = alphabet[n.Int64()]
+	}
+	return string(out), nil
+}
+
+func randomHex(n int) (string, error) {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+func hashCode(code, salt string) string {
+	h := sha256.Sum256([]byte(code + salt))
+	return hex.EncodeToString(h[:])
+}
+
+func renderOTPBody(custom, code string, ttlMinutes int) string {
+	if ttlMinutes < 1 {
+		ttlMinutes = 1
+	}
+	if custom == "" {
+		return fmt.Sprintf("Your verification code is: %s. It expires in %d minute(s). Do not share this code with anyone.", code, ttlMinutes)
+	}
+	body := custom
+	for _, ph := range []string{"{{code}}", "{{ code }}", "{{.code}}"} {
+		body = strings.ReplaceAll(body, ph, code)
+	}
+	for _, ph := range []string{"{{ttl}}", "{{ ttl }}", "{{.ttl}}"} {
+		body = strings.ReplaceAll(body, ph, fmt.Sprintf("%d", ttlMinutes))
+	}
+	return body
+}
+
+func channelToNotificationChannel(c otp.Channel) string {
+	switch c {
+	case otp.ChannelSMS:
+		return "sms"
+	case otp.ChannelWhatsApp:
+		return "whatsapp"
+	case otp.ChannelEmail:
+		return "email"
+	}
+	return ""
+}
+
+// Ensure interface compliance at compile time.
+var _ otp.Service = (*OTPService)(nil)

--- a/internal/usecases/services/otp_service_test.go
+++ b/internal/usecases/services/otp_service_test.go
@@ -1,0 +1,763 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/the-monkeys/freerangenotify/internal/domain/notification"
+	"github.com/the-monkeys/freerangenotify/internal/domain/otp"
+	templateDomain "github.com/the-monkeys/freerangenotify/internal/domain/template"
+	"github.com/the-monkeys/freerangenotify/internal/domain/user"
+)
+
+// ---- Test doubles ---------------------------------------------------------
+
+// fakeOTPRepo is an in-memory implementation of otp.Repository for unit tests.
+// All operations are mutex-guarded so the constant-time concurrent verify
+// test can race a brute-force loop against the attempt counter without flakes.
+type fakeOTPRepo struct {
+	mu       sync.Mutex
+	store    map[string]*otp.Request
+	rlCounts map[string]int
+	failOn   string // when set, the named op returns an error
+}
+
+func newFakeOTPRepo() *fakeOTPRepo {
+	return &fakeOTPRepo{store: map[string]*otp.Request{}, rlCounts: map[string]int{}}
+}
+
+func (f *fakeOTPRepo) Create(_ context.Context, req *otp.Request) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.failOn == "Create" {
+		return errors.New("forced create failure")
+	}
+	cp := *req
+	f.store[req.RequestID] = &cp
+	return nil
+}
+
+func (f *fakeOTPRepo) Get(_ context.Context, id string) (*otp.Request, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	r, ok := f.store[id]
+	if !ok {
+		return nil, otp.ErrNotFound
+	}
+	cp := *r
+	return &cp, nil
+}
+
+func (f *fakeOTPRepo) IncrementAttempts(_ context.Context, id string) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	r, ok := f.store[id]
+	if !ok {
+		return 0, otp.ErrNotFound
+	}
+	r.Attempts++
+	return r.Attempts, nil
+}
+
+func (f *fakeOTPRepo) MarkVerified(_ context.Context, id string, t time.Time) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	r, ok := f.store[id]
+	if !ok {
+		return otp.ErrNotFound
+	}
+	r.Verified = true
+	r.VerifiedAt = &t
+	return nil
+}
+
+func (f *fakeOTPRepo) Update(_ context.Context, req *otp.Request) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	cp := *req
+	f.store[req.RequestID] = &cp
+	return nil
+}
+
+func (f *fakeOTPRepo) Delete(_ context.Context, id string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.store, id)
+	return nil
+}
+
+func (f *fakeOTPRepo) RecipientRateLimit(_ context.Context, appID, recipient string, _ int) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	k := appID + "|" + recipient
+	f.rlCounts[k]++
+	return f.rlCounts[k], nil
+}
+
+// fakeSender captures the most recent notification.SendRequest.
+type fakeSender struct {
+	mu       sync.Mutex
+	calls    []notification.SendRequest
+	nextID   int
+	failNext bool
+}
+
+func (s *fakeSender) Send(_ context.Context, req notification.SendRequest) (*notification.Notification, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.failNext {
+		s.failNext = false
+		return nil, errors.New("forced send failure")
+	}
+	s.calls = append(s.calls, req)
+	s.nextID++
+	return &notification.Notification{NotificationID: "notif-test"}, nil
+}
+
+// fakeUserRepo only implements the methods the OTP service uses (userResolver).
+type fakeUserRepo struct {
+	mu      sync.Mutex
+	byEmail map[string]*user.User
+	byExtID map[string]*user.User
+	byID    map[string]*user.User
+	created []*user.User
+}
+
+func newFakeUserRepo() *fakeUserRepo {
+	return &fakeUserRepo{
+		byEmail: map[string]*user.User{},
+		byExtID: map[string]*user.User{},
+		byID:    map[string]*user.User{},
+	}
+}
+
+func (r *fakeUserRepo) Create(_ context.Context, u *user.User) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if u.Email != "" {
+		r.byEmail[u.AppID+"|"+u.Email] = u
+	}
+	if u.ExternalID != "" {
+		r.byExtID[u.AppID+"|"+u.ExternalID] = u
+	}
+	if u.UserID != "" {
+		r.byID[u.UserID] = u
+	}
+	r.created = append(r.created, u)
+	return nil
+}
+
+func (r *fakeUserRepo) GetByID(_ context.Context, id string) (*user.User, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	u, ok := r.byID[id]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return u, nil
+}
+
+func (r *fakeUserRepo) GetByEmail(_ context.Context, appID, email string) (*user.User, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	u, ok := r.byEmail[appID+"|"+email]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return u, nil
+}
+
+func (r *fakeUserRepo) GetByExternalID(_ context.Context, appID, externalID string) (*user.User, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	u, ok := r.byExtID[appID+"|"+externalID]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return u, nil
+}
+
+// fakeTemplateCreator returns a synthetic template with a stable ID.
+type fakeTemplateCreator struct {
+	mu    sync.Mutex
+	calls []*templateDomain.CreateRequest
+}
+
+func (c *fakeTemplateCreator) Create(_ context.Context, req *templateDomain.CreateRequest) (*templateDomain.Template, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.calls = append(c.calls, req)
+	return &templateDomain.Template{ID: "tmpl-test", AppID: req.AppID, Name: req.Name, Channel: req.Channel, Body: req.Body}, nil
+}
+
+// ---- Helpers --------------------------------------------------------------
+
+func newServiceForTest(t *testing.T) (*OTPService, *fakeOTPRepo, *fakeSender, *fakeUserRepo, *fakeTemplateCreator) {
+	t.Helper()
+	repo := newFakeOTPRepo()
+	sender := &fakeSender{}
+	users := newFakeUserRepo()
+	tmpls := &fakeTemplateCreator{}
+	svc := NewOTPService(repo, sender, users, tmpls, zap.NewNop())
+	return svc, repo, sender, users, tmpls
+}
+
+// ---- Code generation ------------------------------------------------------
+
+func TestGenerateCode_NumericLengthAndAlphabet(t *testing.T) {
+	for _, n := range []int{4, 6, 8, 10} {
+		code, err := generateCode(n, false)
+		if err != nil {
+			t.Fatalf("generateCode(%d, false) error: %v", n, err)
+		}
+		if len(code) != n {
+			t.Errorf("len=%d, want %d", len(code), n)
+		}
+		for _, c := range code {
+			if c < '0' || c > '9' {
+				t.Errorf("non-numeric char %q in %s", c, code)
+			}
+		}
+	}
+}
+
+func TestGenerateCode_AlphanumericExcludesLookalikes(t *testing.T) {
+	// 200 samples × 8 chars = 1600 chars. Probability of *never* drawing
+	// a forbidden char if it were in the alphabet is vanishingly small.
+	forbidden := "0O1Il"
+	for i := 0; i < 200; i++ {
+		code, err := generateCode(8, true)
+		if err != nil {
+			t.Fatalf("generateCode error: %v", err)
+		}
+		if strings.ContainsAny(code, forbidden) {
+			t.Fatalf("alphanumeric code %q contains forbidden lookalike", code)
+		}
+	}
+}
+
+func TestGenerateCode_Distinctness(t *testing.T) {
+	// Two consecutive 6-digit codes should virtually never match — a 1-in-1M
+	// collision is acceptable; we only fail if 100 in a row collide.
+	prev, _ := generateCode(6, false)
+	collisions := 0
+	for i := 0; i < 100; i++ {
+		c, _ := generateCode(6, false)
+		if c == prev {
+			collisions++
+		}
+		prev = c
+	}
+	if collisions == 100 {
+		t.Errorf("100 consecutive identical codes — RNG is broken")
+	}
+}
+
+// ---- Hash + body rendering -----------------------------------------------
+
+func TestHashCode_DeterministicAndSaltDependent(t *testing.T) {
+	h1 := hashCode("123456", "saltA")
+	h2 := hashCode("123456", "saltA")
+	h3 := hashCode("123456", "saltB")
+	if h1 != h2 {
+		t.Errorf("same inputs produced different hashes")
+	}
+	if h1 == h3 {
+		t.Errorf("different salts produced same hash")
+	}
+	if len(h1) != 64 { // SHA-256 hex
+		t.Errorf("expected 64-char hex hash, got %d", len(h1))
+	}
+}
+
+func TestRenderOTPBody_DefaultAndCustom(t *testing.T) {
+	def := renderOTPBody("", "123456", 5)
+	if !strings.Contains(def, "123456") || !strings.Contains(def, "5 minute") {
+		t.Errorf("default body missing code or ttl: %q", def)
+	}
+	custom := renderOTPBody("Code: {{code}} ({{ttl}} min)", "ABCDE", 3)
+	if custom != "Code: ABCDE (3 min)" {
+		t.Errorf("custom render mismatch: %q", custom)
+	}
+}
+
+// ---- Recipient validation ------------------------------------------------
+
+func TestValidateRecipient(t *testing.T) {
+	cases := []struct {
+		channel otp.Channel
+		input   string
+		wantErr bool
+	}{
+		{otp.ChannelEmail, "user@example.com", false},
+		{otp.ChannelEmail, "not-an-email", true},
+		{otp.ChannelSMS, "+14155551234", false},
+		{otp.ChannelSMS, "14155551234", true}, // missing +
+		{otp.ChannelSMS, "+1", true},          // too short
+		{otp.ChannelWhatsApp, "+15555550100", false},
+		{otp.ChannelWhatsApp, "+0123456789", true}, // leading 0 after +
+	}
+	for _, tc := range cases {
+		err := validateRecipient(tc.channel, tc.input)
+		if (err != nil) != tc.wantErr {
+			t.Errorf("validateRecipient(%s, %q) err=%v wantErr=%v", tc.channel, tc.input, err, tc.wantErr)
+		}
+	}
+}
+
+// ---- Service: Send happy path -------------------------------------------
+
+func TestSend_Happy_EmailCreatesUserAndDispatches(t *testing.T) {
+	svc, repo, sender, users, tmpls := newServiceForTest(t)
+	res, err := svc.Send(context.Background(), otp.SendInput{
+		AppID:     "app-1",
+		Channel:   otp.ChannelEmail,
+		Recipient: "alice@example.com",
+	})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if res.RequestID == "" || !strings.HasPrefix(res.RequestID, "otp_") {
+		t.Errorf("unexpected request_id %q", res.RequestID)
+	}
+	if res.NotificationID != "notif-test" {
+		t.Errorf("notification_id = %q", res.NotificationID)
+	}
+	if res.TTLSeconds != otp.DefaultTTLSeconds {
+		t.Errorf("ttl = %d, want default %d", res.TTLSeconds, otp.DefaultTTLSeconds)
+	}
+	if len(sender.calls) != 1 {
+		t.Fatalf("expected 1 send call, got %d", len(sender.calls))
+	}
+	if len(users.created) != 1 {
+		t.Errorf("expected 1 user created, got %d", len(users.created))
+	}
+	if len(tmpls.calls) != 1 {
+		t.Errorf("expected 1 transient template, got %d", len(tmpls.calls))
+	}
+	// Persisted record must NOT contain the plaintext code anywhere.
+	for _, r := range repo.store {
+		if r.CodeHash == "" {
+			t.Errorf("stored record has empty hash")
+		}
+		if len(r.Salt) != 32 { // 16 bytes hex
+			t.Errorf("salt length = %d, want 32 hex chars", len(r.Salt))
+		}
+	}
+}
+
+func TestSend_SMSReusesUserOnSecondCall(t *testing.T) {
+	svc, _, _, users, _ := newServiceForTest(t)
+	for i := 0; i < 2; i++ {
+		if _, err := svc.Send(context.Background(), otp.SendInput{
+			AppID:     "app-1",
+			Channel:   otp.ChannelSMS,
+			Recipient: "+14155551234",
+		}); err != nil {
+			t.Fatalf("Send #%d: %v", i, err)
+		}
+	}
+	if len(users.created) != 1 {
+		t.Errorf("expected 1 user created across 2 sends, got %d", len(users.created))
+	}
+}
+
+// ---- Service: Send validation --------------------------------------------
+
+func TestSend_RejectsInvalidInput(t *testing.T) {
+	cases := []struct {
+		name string
+		in   otp.SendInput
+		want error
+	}{
+		{"empty app", otp.SendInput{Channel: otp.ChannelEmail, Recipient: "a@b.co"}, nil}, // app_id error is non-sentinel
+		{"bad channel", otp.SendInput{AppID: "a", Channel: "push", Recipient: "x@y.z"}, otp.ErrInvalidChannel},
+		{"bad email", otp.SendInput{AppID: "a", Channel: otp.ChannelEmail, Recipient: "nope"}, otp.ErrInvalidRecipient},
+		{"bad phone", otp.SendInput{AppID: "a", Channel: otp.ChannelSMS, Recipient: "555"}, otp.ErrInvalidRecipient},
+		{"length too small", otp.SendInput{AppID: "a", Channel: otp.ChannelSMS, Recipient: "+14155551234", Length: 3}, otp.ErrInvalidLength},
+		{"length too big", otp.SendInput{AppID: "a", Channel: otp.ChannelSMS, Recipient: "+14155551234", Length: 11}, otp.ErrInvalidLength},
+		{"ttl too small", otp.SendInput{AppID: "a", Channel: otp.ChannelSMS, Recipient: "+14155551234", TTLSeconds: 10}, otp.ErrInvalidTTL},
+		{"ttl too big", otp.SendInput{AppID: "a", Channel: otp.ChannelSMS, Recipient: "+14155551234", TTLSeconds: 10000}, otp.ErrInvalidTTL},
+		{"max attempts too big", otp.SendInput{AppID: "a", Channel: otp.ChannelSMS, Recipient: "+14155551234", MaxAttempts: 99}, otp.ErrInvalidAttempts},
+		{"template missing code", otp.SendInput{AppID: "a", Channel: otp.ChannelSMS, Recipient: "+14155551234", TemplateBody: "hello no placeholder"}, otp.ErrTemplateMissingCode},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc, _, _, _, _ := newServiceForTest(t)
+			_, err := svc.Send(context.Background(), tc.in)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if tc.want != nil && !errors.Is(err, tc.want) {
+				t.Errorf("got %v, want %v", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestSend_RateLimited(t *testing.T) {
+	svc, _, _, _, _ := newServiceForTest(t)
+	svc.recipientLimitPerHr = 2
+	for i := 0; i < 2; i++ {
+		if _, err := svc.Send(context.Background(), otp.SendInput{
+			AppID: "a", Channel: otp.ChannelSMS, Recipient: "+14155551234",
+		}); err != nil {
+			t.Fatalf("send #%d: %v", i, err)
+		}
+	}
+	_, err := svc.Send(context.Background(), otp.SendInput{
+		AppID: "a", Channel: otp.ChannelSMS, Recipient: "+14155551234",
+	})
+	if !errors.Is(err, otp.ErrRateLimited) {
+		t.Errorf("expected ErrRateLimited, got %v", err)
+	}
+}
+
+// ---- Service: Verify ------------------------------------------------------
+
+// sendAndCaptureCode wraps Send so a test can recover the plaintext code that
+// was emitted into the notification body — production code never exposes it.
+func sendAndCaptureCode(t *testing.T, svc *OTPService, sender *fakeSender, in otp.SendInput) (*otp.SendResult, string) {
+	t.Helper()
+	res, err := svc.Send(context.Background(), in)
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	sender.mu.Lock()
+	defer sender.mu.Unlock()
+	last := sender.calls[len(sender.calls)-1]
+	code, _ := last.Data["code"].(string)
+	if code == "" {
+		t.Fatalf("no code in notification data")
+	}
+	return res, code
+}
+
+func TestVerify_Success(t *testing.T) {
+	svc, _, sender, _, _ := newServiceForTest(t)
+	res, code := sendAndCaptureCode(t, svc, sender, otp.SendInput{
+		AppID: "a", Channel: otp.ChannelSMS, Recipient: "+14155551234",
+	})
+	v, err := svc.Verify(context.Background(), otp.VerifyInput{RequestID: res.RequestID, Code: code})
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if !v.Verified {
+		t.Errorf("expected verified=true")
+	}
+	if v.VerifiedAt == nil {
+		t.Errorf("expected verified_at to be set")
+	}
+}
+
+func TestVerify_IdempotentOnAlreadyVerified(t *testing.T) {
+	svc, _, sender, _, _ := newServiceForTest(t)
+	res, code := sendAndCaptureCode(t, svc, sender, otp.SendInput{
+		AppID: "a", Channel: otp.ChannelSMS, Recipient: "+14155551234",
+	})
+	if _, err := svc.Verify(context.Background(), otp.VerifyInput{RequestID: res.RequestID, Code: code}); err != nil {
+		t.Fatalf("first verify: %v", err)
+	}
+	// Second verify with same code must succeed without consuming an attempt.
+	v2, err := svc.Verify(context.Background(), otp.VerifyInput{RequestID: res.RequestID, Code: code})
+	if err != nil || !v2.Verified {
+		t.Errorf("idempotent re-verify failed: %v / %+v", err, v2)
+	}
+}
+
+func TestVerify_InvalidCodeConsumesAttempt(t *testing.T) {
+	svc, repo, sender, _, _ := newServiceForTest(t)
+	res, _ := sendAndCaptureCode(t, svc, sender, otp.SendInput{
+		AppID: "a", Channel: otp.ChannelSMS, Recipient: "+14155551234",
+	})
+	v, err := svc.Verify(context.Background(), otp.VerifyInput{RequestID: res.RequestID, Code: "000000"})
+	if !errors.Is(err, otp.ErrInvalidCode) {
+		t.Fatalf("got %v, want ErrInvalidCode", err)
+	}
+	if v == nil || v.AttemptsRemaining != otp.DefaultMaxAttempts-1 {
+		t.Errorf("attempts_remaining = %+v, want %d", v, otp.DefaultMaxAttempts-1)
+	}
+	stored := repo.store[res.RequestID]
+	if stored.Attempts != 1 {
+		t.Errorf("repo attempts = %d, want 1", stored.Attempts)
+	}
+}
+
+func TestVerify_AttemptsExhausted(t *testing.T) {
+	svc, repo, sender, _, _ := newServiceForTest(t)
+	res, _ := sendAndCaptureCode(t, svc, sender, otp.SendInput{
+		AppID: "a", Channel: otp.ChannelSMS, Recipient: "+14155551234",
+		MaxAttempts: 2,
+	})
+	// Two wrong attempts, then a third must hit exhaustion.
+	_, _ = svc.Verify(context.Background(), otp.VerifyInput{RequestID: res.RequestID, Code: "000000"})
+	_, _ = svc.Verify(context.Background(), otp.VerifyInput{RequestID: res.RequestID, Code: "000000"})
+	_, err := svc.Verify(context.Background(), otp.VerifyInput{RequestID: res.RequestID, Code: "000000"})
+	if !errors.Is(err, otp.ErrAttemptsExhausted) {
+		t.Fatalf("got %v, want ErrAttemptsExhausted", err)
+	}
+	if _, ok := repo.store[res.RequestID]; ok {
+		t.Errorf("expected record to be deleted on exhaustion")
+	}
+}
+
+func TestVerify_Expired(t *testing.T) {
+	svc, repo, sender, _, _ := newServiceForTest(t)
+	res, code := sendAndCaptureCode(t, svc, sender, otp.SendInput{
+		AppID: "a", Channel: otp.ChannelSMS, Recipient: "+14155551234",
+	})
+	// Force expiry in the fake repo.
+	stored := repo.store[res.RequestID]
+	stored.ExpiresAt = time.Now().UTC().Add(-1 * time.Minute)
+
+	_, err := svc.Verify(context.Background(), otp.VerifyInput{RequestID: res.RequestID, Code: code})
+	if !errors.Is(err, otp.ErrExpired) {
+		t.Errorf("got %v, want ErrExpired", err)
+	}
+}
+
+func TestVerify_NotFound(t *testing.T) {
+	svc, _, _, _, _ := newServiceForTest(t)
+	_, err := svc.Verify(context.Background(), otp.VerifyInput{RequestID: "otp_bogus", Code: "123456"})
+	if !errors.Is(err, otp.ErrNotFound) {
+		t.Errorf("got %v, want ErrNotFound", err)
+	}
+}
+
+func TestVerify_EmptyInputs(t *testing.T) {
+	svc, _, _, _, _ := newServiceForTest(t)
+	_, err := svc.Verify(context.Background(), otp.VerifyInput{RequestID: "", Code: ""})
+	if !errors.Is(err, otp.ErrInvalidCode) {
+		t.Errorf("got %v, want ErrInvalidCode", err)
+	}
+}
+
+// ---- Service: Resend -----------------------------------------------------
+
+func TestResend_NewCodeOldCodeRejected(t *testing.T) {
+	svc, repo, sender, _, _ := newServiceForTest(t)
+	svc.resendCooldownSec = 0 // disable cooldown for test
+	res, oldCode := sendAndCaptureCode(t, svc, sender, otp.SendInput{
+		AppID: "a", Channel: otp.ChannelSMS, Recipient: "+14155551234",
+	})
+
+	// Resend — must succeed and mint a new code.
+	r2, err := svc.Resend(context.Background(), res.RequestID)
+	if err != nil {
+		t.Fatalf("Resend: %v", err)
+	}
+	if r2.RequestID != res.RequestID {
+		t.Errorf("resend changed request_id: %q -> %q", res.RequestID, r2.RequestID)
+	}
+	sender.mu.Lock()
+	newCode, _ := sender.calls[len(sender.calls)-1].Data["code"].(string)
+	sender.mu.Unlock()
+	if newCode == oldCode {
+		t.Errorf("resend should issue a new code")
+	}
+
+	// Old code must no longer verify.
+	_, err = svc.Verify(context.Background(), otp.VerifyInput{RequestID: res.RequestID, Code: oldCode})
+	if !errors.Is(err, otp.ErrInvalidCode) {
+		t.Errorf("old code accepted after resend: %v", err)
+	}
+	// New code must verify and attempt counter must have been reset.
+	stored := repo.store[res.RequestID]
+	if stored.Attempts != 1 { // the failed-old-code call above consumed 1
+		t.Errorf("expected attempts=1 after one bad verify post-resend, got %d", stored.Attempts)
+	}
+}
+
+func TestResend_CooldownEnforced(t *testing.T) {
+	svc, _, sender, _, _ := newServiceForTest(t)
+	// Default cooldown is 60s; the just-sent record's LastSentAt = now, so a
+	// resend immediately must be rejected.
+	res, _ := sendAndCaptureCode(t, svc, sender, otp.SendInput{
+		AppID: "a", Channel: otp.ChannelSMS, Recipient: "+14155551234",
+	})
+	_, err := svc.Resend(context.Background(), res.RequestID)
+	if !errors.Is(err, otp.ErrResendCooldown) {
+		t.Errorf("got %v, want ErrResendCooldown", err)
+	}
+}
+
+func TestResend_AlreadyVerified(t *testing.T) {
+	svc, _, sender, _, _ := newServiceForTest(t)
+	svc.resendCooldownSec = 0
+	res, code := sendAndCaptureCode(t, svc, sender, otp.SendInput{
+		AppID: "a", Channel: otp.ChannelSMS, Recipient: "+14155551234",
+	})
+	if _, err := svc.Verify(context.Background(), otp.VerifyInput{RequestID: res.RequestID, Code: code}); err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	_, err := svc.Resend(context.Background(), res.RequestID)
+	if !errors.Is(err, otp.ErrAlreadyVerified) {
+		t.Errorf("got %v, want ErrAlreadyVerified", err)
+	}
+}
+
+func TestResend_NotFound(t *testing.T) {
+	svc, _, _, _, _ := newServiceForTest(t)
+	_, err := svc.Resend(context.Background(), "otp_bogus")
+	if !errors.Is(err, otp.ErrNotFound) {
+		t.Errorf("got %v, want ErrNotFound", err)
+	}
+}
+
+// ---- Brute-force resistance ---------------------------------------------
+
+func TestVerify_BruteForceLockedOutBeforeGuessing(t *testing.T) {
+	svc, _, sender, _, _ := newServiceForTest(t)
+	res, realCode := sendAndCaptureCode(t, svc, sender, otp.SendInput{
+		AppID: "a", Channel: otp.ChannelSMS, Recipient: "+14155551234",
+		Length: 4, MaxAttempts: 3,
+	})
+	// Three wrong guesses exhaust the budget; the 4th call returns
+	// ErrAttemptsExhausted even if it would have been the correct code.
+	for i := 0; i < 3; i++ {
+		_, _ = svc.Verify(context.Background(), otp.VerifyInput{RequestID: res.RequestID, Code: "0000"})
+	}
+	_, err := svc.Verify(context.Background(), otp.VerifyInput{RequestID: res.RequestID, Code: realCode})
+	if !errors.Is(err, otp.ErrAttemptsExhausted) && !errors.Is(err, otp.ErrNotFound) {
+		// Either is acceptable — exhaustion may have deleted the record.
+		t.Errorf("after exhaustion, got %v; want ErrAttemptsExhausted or ErrNotFound", err)
+	}
+}
+
+// ---- Recipient resolution via user_id / external_id ----------------------
+
+func TestSend_ResolvesByExternalID_UsesUserEmail(t *testing.T) {
+	svc, repo, sender, users, _ := newServiceForTest(t)
+	// Seed a known user with both contact fields.
+	u := &user.User{
+		UserID:     "u-1",
+		AppID:      "app-1",
+		ExternalID: "ext-abc",
+		Email:      "found@example.com",
+		Phone:      "+14155551234",
+	}
+	_ = users.Create(context.Background(), u)
+
+	res, err := svc.Send(context.Background(), otp.SendInput{
+		AppID:      "app-1",
+		Channel:    otp.ChannelEmail,
+		ExternalID: "ext-abc",
+	})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if res == nil || res.RequestID == "" {
+		t.Fatalf("missing result")
+	}
+	// Persisted record's Recipient must be the user's email, not the
+	// external_id we passed in.
+	persisted, _ := repo.Get(context.Background(), res.RequestID)
+	if persisted.Recipient != "found@example.com" {
+		t.Errorf("persisted.Recipient = %q; want %q", persisted.Recipient, "found@example.com")
+	}
+	// Notification must be addressed to the existing user (no auto-create).
+	if got := sender.calls[len(sender.calls)-1].UserID; got != "u-1" {
+		t.Errorf("notification UserID = %q; want u-1", got)
+	}
+	if len(users.created) != 1 {
+		t.Errorf("expected exactly 1 user (the seed), got %d", len(users.created))
+	}
+}
+
+func TestSend_ResolvesByUserID_UsesUserPhoneForSMS(t *testing.T) {
+	svc, _, sender, users, _ := newServiceForTest(t)
+	u := &user.User{
+		UserID: "u-2",
+		AppID:  "app-1",
+		Email:  "x@example.com",
+		Phone:  "+15555550100",
+	}
+	_ = users.Create(context.Background(), u)
+
+	res, err := svc.Send(context.Background(), otp.SendInput{
+		AppID:   "app-1",
+		Channel: otp.ChannelSMS,
+		UserID:  "u-2",
+	})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if sender.calls[len(sender.calls)-1].UserID != "u-2" {
+		t.Errorf("notification UserID = %q; want u-2", sender.calls[len(sender.calls)-1].UserID)
+	}
+	if res == nil {
+		t.Fatal("nil result")
+	}
+}
+
+func TestSend_UserID_CrossTenant_Rejected(t *testing.T) {
+	svc, _, _, users, _ := newServiceForTest(t)
+	u := &user.User{UserID: "u-3", AppID: "OTHER-APP", Email: "x@example.com"}
+	_ = users.Create(context.Background(), u)
+
+	_, err := svc.Send(context.Background(), otp.SendInput{
+		AppID:   "app-1",
+		Channel: otp.ChannelEmail,
+		UserID:  "u-3",
+	})
+	if !errors.Is(err, otp.ErrUserNotFound) {
+		t.Errorf("err = %v; want ErrUserNotFound", err)
+	}
+}
+
+func TestSend_ExternalID_NotFound(t *testing.T) {
+	svc, _, _, _, _ := newServiceForTest(t)
+	_, err := svc.Send(context.Background(), otp.SendInput{
+		AppID:      "app-1",
+		Channel:    otp.ChannelEmail,
+		ExternalID: "missing",
+	})
+	if !errors.Is(err, otp.ErrUserNotFound) {
+		t.Errorf("err = %v; want ErrUserNotFound", err)
+	}
+}
+
+func TestSend_UserMissingChannelAddress(t *testing.T) {
+	svc, _, _, users, _ := newServiceForTest(t)
+	u := &user.User{UserID: "u-4", AppID: "app-1", ExternalID: "ext-no-phone", Email: "noemail-but-has@example.com"}
+	_ = users.Create(context.Background(), u)
+
+	_, err := svc.Send(context.Background(), otp.SendInput{
+		AppID:      "app-1",
+		Channel:    otp.ChannelSMS, // user has no phone
+		ExternalID: "ext-no-phone",
+	})
+	if !errors.Is(err, otp.ErrUserMissingChannelAddress) {
+		t.Errorf("err = %v; want ErrUserMissingChannelAddress", err)
+	}
+}
+
+func TestSend_AmbiguousRecipient_Rejected(t *testing.T) {
+	svc, _, _, _, _ := newServiceForTest(t)
+	_, err := svc.Send(context.Background(), otp.SendInput{
+		AppID:      "app-1",
+		Channel:    otp.ChannelEmail,
+		Recipient:  "a@b.com",
+		ExternalID: "ext-1",
+	})
+	if !errors.Is(err, otp.ErrAmbiguousRecipient) {
+		t.Errorf("err = %v; want ErrAmbiguousRecipient", err)
+	}
+}
+
+func TestSend_NoIdentifier_Rejected(t *testing.T) {
+	svc, _, _, _, _ := newServiceForTest(t)
+	_, err := svc.Send(context.Background(), otp.SendInput{
+		AppID:   "app-1",
+		Channel: otp.ChannelEmail,
+	})
+	if !errors.Is(err, otp.ErrInvalidRecipient) {
+		t.Errorf("err = %v; want ErrInvalidRecipient", err)
+	}
+}

--- a/sdk/go/freerangenotify/client.go
+++ b/sdk/go/freerangenotify/client.go
@@ -41,6 +41,7 @@ type Client struct {
 	Workflows     *WorkflowsClient
 	Topics        *TopicsClient
 	Presence      *PresenceClient
+	OTP           *OTPClient
 }
 
 // Option configures the Client.
@@ -79,6 +80,7 @@ func New(apiKey string, opts ...Option) *Client {
 	c.Workflows = &WorkflowsClient{client: c}
 	c.Topics = &TopicsClient{client: c}
 	c.Presence = &PresenceClient{client: c}
+	c.OTP = &OTPClient{client: c}
 	return c
 }
 

--- a/sdk/go/freerangenotify/otp.go
+++ b/sdk/go/freerangenotify/otp.go
@@ -1,0 +1,274 @@
+package freerangenotify
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+)
+
+// ── OTPClient ─────────────────────────────────────────────────────────────
+
+// OTPClient handles OTP-as-a-service operations (POST /v1/otp/*).
+//
+// Usage:
+//
+//	res, err := client.OTP.Send(ctx, freerangenotify.OTPSendParams{
+//	    Channel:   freerangenotify.OTPChannelSMS,
+//	    Recipient: "+14155551212",
+//	})
+//	if err != nil { /* ... */ }
+//
+//	verify, err := client.OTP.Verify(ctx, freerangenotify.OTPVerifyParams{
+//	    RequestID: res.RequestID,
+//	    Code:      userInput,
+//	})
+//	switch {
+//	case errors.Is(err, freerangenotify.ErrOTPInvalidCode):
+//	    // show "wrong code, X attempts left" using verify.AttemptsRemaining
+//	case errors.Is(err, freerangenotify.ErrOTPExpired):
+//	    // prompt user to request a new code
+//	case err != nil:
+//	    return err
+//	default:
+//	    // verify.Verified == true
+//	}
+type OTPClient struct {
+	client *Client
+}
+
+// OTPChannel is the delivery channel for an OTP.
+type OTPChannel string
+
+const (
+	OTPChannelSMS      OTPChannel = "sms"
+	OTPChannelWhatsApp OTPChannel = "whatsapp"
+	OTPChannelEmail    OTPChannel = "email"
+)
+
+// ── Params / Results ──────────────────────────────────────────────────────
+
+// OTPSendParams is the request for OTP.Send. Exactly one of Recipient,
+// UserID, or ExternalID must be supplied:
+//   - Recipient:  raw email / E.164 phone. The user record (if any) is
+//     auto-created on first use.
+//   - UserID:     the internal FRN user_id (UUID). The channel-appropriate
+//     contact address (email or phone) is read from the user record.
+//   - ExternalID: the caller-owned user identifier. Same resolution behaviour
+//     as UserID, but looked up via the users index.
+type OTPSendParams struct {
+	// Channel is the delivery channel. Required.
+	Channel OTPChannel `json:"channel"`
+	// Recipient is E.164 phone for sms/whatsapp or an RFC 5322 email address.
+	// Mutually exclusive with UserID / ExternalID.
+	Recipient string `json:"recipient,omitempty"`
+	// UserID is the internal FRN user_id (UUID). Mutually exclusive with
+	// Recipient / ExternalID.
+	UserID string `json:"user_id,omitempty"`
+	// ExternalID is the caller-owned user identifier. Mutually exclusive
+	// with Recipient / UserID.
+	ExternalID string `json:"external_id,omitempty"`
+
+	// Length is the code length (4–10). 0 → server default (6).
+	Length int `json:"length,omitempty"`
+	// Alphanumeric draws codes from a lookalike-free alphabet instead of digits.
+	Alphanumeric bool `json:"alphanumeric,omitempty"`
+	// TTLSeconds is the code lifetime in seconds (30–900). 0 → server default (300).
+	TTLSeconds int `json:"ttl_seconds,omitempty"`
+	// MaxAttempts is the verify-attempt budget (1–10). 0 → server default (5).
+	MaxAttempts int `json:"max_attempts,omitempty"`
+
+	// TemplateBody is an optional bring-your-own message body containing {{code}}.
+	// Empty → server uses a channel-appropriate default.
+	TemplateBody string `json:"template_body,omitempty"`
+	// TemplateData carries extra variables (e.g. {"app_name":"Acme"}) for TemplateBody.
+	TemplateData map[string]interface{} `json:"template_data,omitempty"`
+}
+
+// OTPSendResult is the response from OTP.Send / OTP.Resend.
+type OTPSendResult struct {
+	RequestID      string     `json:"request_id"`
+	NotificationID string     `json:"notification_id"`
+	Channel        OTPChannel `json:"channel"`
+	ExpiresAt      string     `json:"expires_at"`
+	TTLSeconds     int        `json:"ttl_seconds"`
+	MaxAttempts    int        `json:"max_attempts"`
+}
+
+// OTPVerifyParams is the request for OTP.Verify.
+type OTPVerifyParams struct {
+	RequestID string `json:"request_id"`
+	Code      string `json:"code"`
+}
+
+// OTPVerifyResult is the response from OTP.Verify. On failure, the SDK returns
+// (result, err) where result carries AttemptsRemaining and err matches one of
+// the ErrOTP* sentinels (use errors.Is).
+type OTPVerifyResult struct {
+	Verified          bool   `json:"verified"`
+	RequestID         string `json:"request_id"`
+	VerifiedAt        string `json:"verified_at,omitempty"`
+	AttemptsRemaining int    `json:"attempts_remaining,omitempty"`
+	Error             string `json:"error,omitempty"`
+}
+
+// ── Sentinel errors ───────────────────────────────────────────────────────
+
+// OTP-specific sentinel errors. Use errors.Is for matching:
+//
+//	if errors.Is(err, freerangenotify.ErrOTPInvalidCode) { ... }
+//
+// They are returned by OTP.Send / OTP.Verify / OTP.Resend whenever the API
+// responds with a known OTP failure mode, regardless of HTTP status. Unknown
+// failures fall through as *APIError.
+var (
+	ErrOTPInvalidCode       = errors.New("freerangenotify: invalid OTP code")
+	ErrOTPAttemptsExhausted = errors.New("freerangenotify: OTP attempts exhausted")
+	ErrOTPExpired           = errors.New("freerangenotify: OTP expired")
+	ErrOTPNotFound          = errors.New("freerangenotify: OTP request not found")
+	ErrOTPAlreadyVerified   = errors.New("freerangenotify: OTP already verified")
+	ErrOTPResendCooldown    = errors.New("freerangenotify: OTP resend cooldown active")
+	ErrOTPRateLimited       = errors.New("freerangenotify: OTP per-recipient rate limit exceeded")
+)
+
+// ── Operations ────────────────────────────────────────────────────────────
+
+// Send generates an OTP, hashes it, and dispatches it via the requested channel.
+// Returns ErrOTPRateLimited on 429.
+func (o *OTPClient) Send(ctx context.Context, params OTPSendParams) (*OTPSendResult, error) {
+	var result OTPSendResult
+	err := o.client.do(ctx, "POST", "/otp/send", params, &result)
+	if err != nil {
+		return nil, classifyOTPSendError(err)
+	}
+	return &result, nil
+}
+
+// Verify checks a user-supplied code against the OTP identified by request_id.
+//
+// On invalid code, returns (result, ErrOTPInvalidCode) so callers can read
+// result.AttemptsRemaining to drive UX. On hard failures (expired, not_found,
+// attempts exhausted), the corresponding ErrOTP* sentinel is returned and the
+// returned result may be partial. Unknown failures return a wrapped *APIError.
+func (o *OTPClient) Verify(ctx context.Context, params OTPVerifyParams) (*OTPVerifyResult, error) {
+	var result OTPVerifyResult
+	err := o.client.do(ctx, "POST", "/otp/verify", params, &result)
+	if err == nil {
+		return &result, nil
+	}
+	// The verify endpoint returns its OTPVerifyResponse JSON even on 4xx, so
+	// try to surface AttemptsRemaining alongside the sentinel error. We decode
+	// the body that the transport already captured into result via the
+	// pre-error path is not available, so re-do the request only if needed.
+	// In practice the transport in client.go returns *APIError with Body set;
+	// we parse it best-effort here.
+	if apiErr, ok := err.(*APIError); ok {
+		if parsed := parseVerifyBody(apiErr.Body); parsed != nil {
+			result = *parsed
+		}
+	}
+	return &result, classifyOTPVerifyError(err, result.Error)
+}
+
+// Resend re-issues a fresh code for an existing request_id (60 s cooldown).
+// The previous code is invalidated and the attempt counter resets.
+func (o *OTPClient) Resend(ctx context.Context, requestID string) (*OTPSendResult, error) {
+	var result OTPSendResult
+	err := o.client.do(ctx, "POST", "/otp/resend", map[string]string{"request_id": requestID}, &result)
+	if err != nil {
+		return nil, classifyOTPSendError(err)
+	}
+	return &result, nil
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────────
+
+// classifyOTPSendError maps a transport-level error to an OTP sentinel by
+// matching on HTTP status + body. Unknown errors pass through unchanged.
+func classifyOTPSendError(err error) error {
+	apiErr, ok := err.(*APIError)
+	if !ok {
+		return err
+	}
+	body := apiErr.Body
+	switch apiErr.StatusCode {
+	case 404:
+		return wrapAPIErr(apiErr, ErrOTPNotFound)
+	case 410:
+		return wrapAPIErr(apiErr, ErrOTPExpired)
+	case 409:
+		if strings.Contains(body, "already verified") {
+			return wrapAPIErr(apiErr, ErrOTPAlreadyVerified)
+		}
+		if strings.Contains(body, "cooldown") {
+			return wrapAPIErr(apiErr, ErrOTPResendCooldown)
+		}
+	case 429:
+		return wrapAPIErr(apiErr, ErrOTPRateLimited)
+	}
+	return apiErr
+}
+
+// classifyOTPVerifyError maps verify-endpoint errors. The verify endpoint
+// returns a structured body with an `error` discriminator that is more
+// reliable than HTTP-status sniffing for the 400 cases (invalid_code vs
+// attempts_exhausted both come back as 400).
+func classifyOTPVerifyError(err error, errCode string) error {
+	apiErr, ok := err.(*APIError)
+	if !ok {
+		return err
+	}
+	switch errCode {
+	case "invalid_code":
+		return wrapAPIErr(apiErr, ErrOTPInvalidCode)
+	case "attempts_exhausted":
+		return wrapAPIErr(apiErr, ErrOTPAttemptsExhausted)
+	case "expired":
+		return wrapAPIErr(apiErr, ErrOTPExpired)
+	case "not_found":
+		return wrapAPIErr(apiErr, ErrOTPNotFound)
+	}
+	// Fall back to status-based mapping for cases where the body discriminator
+	// is missing (e.g. validation errors, 401, 500).
+	switch apiErr.StatusCode {
+	case 404:
+		return wrapAPIErr(apiErr, ErrOTPNotFound)
+	case 410:
+		return wrapAPIErr(apiErr, ErrOTPExpired)
+	}
+	return apiErr
+}
+
+// wrappedOTPErr keeps the original *APIError available via errors.As while
+// matching one of the ErrOTP* sentinels via errors.Is.
+type wrappedOTPErr struct {
+	sentinel error
+	api      *APIError
+}
+
+func (w *wrappedOTPErr) Error() string { return w.sentinel.Error() + ": " + w.api.Error() }
+func (w *wrappedOTPErr) Unwrap() error { return w.api }
+func (w *wrappedOTPErr) Is(target error) bool {
+	return target == w.sentinel
+}
+
+func wrapAPIErr(api *APIError, sentinel error) error {
+	return &wrappedOTPErr{sentinel: sentinel, api: api}
+}
+
+// parseVerifyBody attempts to decode an OTPVerifyResult out of an error
+// response body. Returns nil on failure — the caller falls back to the
+// zero-value result.
+func parseVerifyBody(body string) *OTPVerifyResult {
+	if body == "" {
+		return nil
+	}
+	var out OTPVerifyResult
+	if err := json.Unmarshal([]byte(body), &out); err != nil {
+		return nil
+	}
+	if out.Error == "" && !out.Verified {
+		return nil
+	}
+	return &out
+}

--- a/sdk/go/freerangenotify/otp_test.go
+++ b/sdk/go/freerangenotify/otp_test.go
@@ -1,0 +1,309 @@
+package freerangenotify
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ─── Send ───────────────────────────────────────────────────────────────────
+
+func TestOTPClient_Send_Success(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/v1/otp/send", r.URL.Path)
+		assert.Equal(t, "Bearer test-key", r.Header.Get("Authorization"))
+
+		var body OTPSendParams
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, OTPChannelSMS, body.Channel)
+		assert.Equal(t, "+14155551212", body.Recipient)
+
+		w.WriteHeader(http.StatusAccepted)
+		_ = json.NewEncoder(w).Encode(OTPSendResult{
+			RequestID:      "req-1",
+			NotificationID: "notif-1",
+			Channel:        OTPChannelSMS,
+			ExpiresAt:      "2026-05-24T12:35:00Z",
+			TTLSeconds:     300,
+			MaxAttempts:    5,
+		})
+	}))
+	defer ts.Close()
+
+	c := New("test-key", WithBaseURL(ts.URL+"/v1"))
+	res, err := c.OTP.Send(context.Background(), OTPSendParams{
+		Channel:   OTPChannelSMS,
+		Recipient: "+14155551212",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "req-1", res.RequestID)
+	assert.Equal(t, "notif-1", res.NotificationID)
+	assert.Equal(t, OTPChannelSMS, res.Channel)
+	assert.Equal(t, 300, res.TTLSeconds)
+}
+
+func TestOTPClient_Send_AllOptionalFieldsForwarded(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, "email", body["channel"])
+		assert.Equal(t, float64(8), body["length"])
+		assert.Equal(t, true, body["alphanumeric"])
+		assert.Equal(t, float64(600), body["ttl_seconds"])
+		assert.Equal(t, float64(3), body["max_attempts"])
+		assert.Equal(t, "Your code is {{code}}", body["template_body"])
+		assert.Equal(t, map[string]interface{}{"app_name": "Acme"}, body["template_data"])
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte(`{"request_id":"r","channel":"email"}`))
+	}))
+	defer ts.Close()
+
+	c := New("test-key", WithBaseURL(ts.URL+"/v1"))
+	_, err := c.OTP.Send(context.Background(), OTPSendParams{
+		Channel:      OTPChannelEmail,
+		Recipient:    "user@example.com",
+		Length:       8,
+		Alphanumeric: true,
+		TTLSeconds:   600,
+		MaxAttempts:  3,
+		TemplateBody: "Your code is {{code}}",
+		TemplateData: map[string]interface{}{"app_name": "Acme"},
+	})
+	require.NoError(t, err)
+}
+
+func TestOTPClient_Send_OmitsZeroValues(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		_, hasLen := body["length"]
+		_, hasTTL := body["ttl_seconds"]
+		_, hasMax := body["max_attempts"]
+		_, hasTpl := body["template_body"]
+		assert.False(t, hasLen, "length should be omitted when zero")
+		assert.False(t, hasTTL, "ttl_seconds should be omitted when zero")
+		assert.False(t, hasMax, "max_attempts should be omitted when zero")
+		assert.False(t, hasTpl, "template_body should be omitted when empty")
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte(`{"request_id":"r"}`))
+	}))
+	defer ts.Close()
+
+	c := New("test-key", WithBaseURL(ts.URL+"/v1"))
+	_, err := c.OTP.Send(context.Background(), OTPSendParams{
+		Channel:   OTPChannelSMS,
+		Recipient: "+14155551212",
+	})
+	require.NoError(t, err)
+}
+
+func TestOTPClient_Send_RateLimited(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":"rate limit exceeded"}`))
+	}))
+	defer ts.Close()
+
+	c := New("test-key", WithBaseURL(ts.URL+"/v1"))
+	res, err := c.OTP.Send(context.Background(), OTPSendParams{Channel: OTPChannelSMS, Recipient: "+1"})
+	assert.Nil(t, res)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrOTPRateLimited))
+
+	// Original *APIError must still be reachable via errors.As.
+	var apiErr *APIError
+	require.True(t, errors.As(err, &apiErr))
+	assert.Equal(t, http.StatusTooManyRequests, apiErr.StatusCode)
+}
+
+func TestOTPClient_Send_ValidationError_UnchangedAPIError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid recipient"}`))
+	}))
+	defer ts.Close()
+
+	c := New("test-key", WithBaseURL(ts.URL+"/v1"))
+	_, err := c.OTP.Send(context.Background(), OTPSendParams{Channel: OTPChannelSMS, Recipient: "bogus"})
+	require.Error(t, err)
+	// 400 is not classified by the SDK — caller inspects *APIError.
+	assert.False(t, errors.Is(err, ErrOTPRateLimited))
+	var apiErr *APIError
+	require.True(t, errors.As(err, &apiErr))
+	assert.True(t, apiErr.IsValidationError())
+}
+
+// ─── Verify ─────────────────────────────────────────────────────────────────
+
+func TestOTPClient_Verify_Success(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v1/otp/verify", r.URL.Path)
+		var body OTPVerifyParams
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, "req-1", body.RequestID)
+		assert.Equal(t, "482913", body.Code)
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"verified":true,"request_id":"req-1","verified_at":"2026-05-24T12:31:42Z"}`))
+	}))
+	defer ts.Close()
+
+	c := New("test-key", WithBaseURL(ts.URL+"/v1"))
+	res, err := c.OTP.Verify(context.Background(), OTPVerifyParams{RequestID: "req-1", Code: "482913"})
+	require.NoError(t, err)
+	assert.True(t, res.Verified)
+	assert.Equal(t, "2026-05-24T12:31:42Z", res.VerifiedAt)
+}
+
+func TestOTPClient_Verify_InvalidCode_ReturnsSentinelAndAttemptsRemaining(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"verified":false,"request_id":"req-1","error":"invalid_code","attempts_remaining":3}`))
+	}))
+	defer ts.Close()
+
+	c := New("test-key", WithBaseURL(ts.URL+"/v1"))
+	res, err := c.OTP.Verify(context.Background(), OTPVerifyParams{RequestID: "req-1", Code: "000000"})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrOTPInvalidCode))
+	require.NotNil(t, res)
+	assert.False(t, res.Verified)
+	assert.Equal(t, 3, res.AttemptsRemaining)
+}
+
+func TestOTPClient_Verify_AttemptsExhausted(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"verified":false,"error":"attempts_exhausted"}`))
+	}))
+	defer ts.Close()
+
+	c := New("test-key", WithBaseURL(ts.URL+"/v1"))
+	_, err := c.OTP.Verify(context.Background(), OTPVerifyParams{RequestID: "req-1", Code: "000000"})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrOTPAttemptsExhausted))
+	// Must NOT also match ErrOTPInvalidCode.
+	assert.False(t, errors.Is(err, ErrOTPInvalidCode))
+}
+
+func TestOTPClient_Verify_Expired(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusGone)
+		_, _ = w.Write([]byte(`{"verified":false,"error":"expired"}`))
+	}))
+	defer ts.Close()
+
+	c := New("test-key", WithBaseURL(ts.URL+"/v1"))
+	_, err := c.OTP.Verify(context.Background(), OTPVerifyParams{RequestID: "req-1", Code: "1"})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrOTPExpired))
+}
+
+func TestOTPClient_Verify_NotFound(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"verified":false,"error":"not_found"}`))
+	}))
+	defer ts.Close()
+
+	c := New("test-key", WithBaseURL(ts.URL+"/v1"))
+	_, err := c.OTP.Verify(context.Background(), OTPVerifyParams{RequestID: "missing", Code: "1"})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrOTPNotFound))
+}
+
+func TestOTPClient_Verify_StatusFallback_NoErrorDiscriminator(t *testing.T) {
+	// When the body doesn't carry the `error` field (older servers / proxies),
+	// the SDK must still classify via HTTP status for the unambiguous cases.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusGone)
+		_, _ = w.Write([]byte(`{"error":"OTP expired"}`))
+	}))
+	defer ts.Close()
+
+	c := New("test-key", WithBaseURL(ts.URL+"/v1"))
+	_, err := c.OTP.Verify(context.Background(), OTPVerifyParams{RequestID: "r", Code: "1"})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrOTPExpired))
+}
+
+func TestOTPClient_Verify_ServerError_UnchangedAPIError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"boom"}`))
+	}))
+	defer ts.Close()
+
+	c := New("test-key", WithBaseURL(ts.URL+"/v1"))
+	_, err := c.OTP.Verify(context.Background(), OTPVerifyParams{RequestID: "r", Code: "1"})
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, ErrOTPInvalidCode))
+	assert.False(t, errors.Is(err, ErrOTPExpired))
+	var apiErr *APIError
+	require.True(t, errors.As(err, &apiErr))
+	assert.Equal(t, 500, apiErr.StatusCode)
+}
+
+// ─── Resend ─────────────────────────────────────────────────────────────────
+
+func TestOTPClient_Resend_Success(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v1/otp/resend", r.URL.Path)
+		var body map[string]string
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, "req-1", body["request_id"])
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte(`{"request_id":"req-1","notification_id":"notif-2","channel":"sms"}`))
+	}))
+	defer ts.Close()
+
+	c := New("test-key", WithBaseURL(ts.URL+"/v1"))
+	res, err := c.OTP.Resend(context.Background(), "req-1")
+	require.NoError(t, err)
+	assert.Equal(t, "req-1", res.RequestID)
+	assert.Equal(t, "notif-2", res.NotificationID)
+}
+
+func TestOTPClient_Resend_ErrorMapping(t *testing.T) {
+	cases := []struct {
+		name     string
+		status   int
+		body     string
+		sentinel error
+	}{
+		{"not_found", http.StatusNotFound, `{"error":"not found"}`, ErrOTPNotFound},
+		{"expired", http.StatusGone, `{"error":"expired"}`, ErrOTPExpired},
+		{"already_verified", http.StatusConflict, `{"error":"already verified"}`, ErrOTPAlreadyVerified},
+		{"cooldown", http.StatusConflict, `{"error":"resend cooldown active"}`, ErrOTPResendCooldown},
+		{"rate_limited", http.StatusTooManyRequests, `{"error":"rate limited"}`, ErrOTPRateLimited},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer ts.Close()
+
+			c := New("test-key", WithBaseURL(ts.URL+"/v1"))
+			_, err := c.OTP.Resend(context.Background(), "req-1")
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, tc.sentinel), "expected sentinel %v, got %v", tc.sentinel, err)
+		})
+	}
+}
+
+// ─── Wiring ─────────────────────────────────────────────────────────────────
+
+func TestOTPClient_IsWiredIntoClient(t *testing.T) {
+	c := New("test-key")
+	require.NotNil(t, c.OTP)
+	assert.Same(t, c, c.OTP.client)
+}

--- a/sdk/js/src/index.ts
+++ b/sdk/js/src/index.ts
@@ -22,6 +22,7 @@ import { TemplatesClient } from './templates';
 import { WorkflowsClient } from './workflows';
 import { TopicsClient } from './topics';
 import { PresenceClient } from './presence';
+import { OTPClient } from './otp';
 import { connectSSE } from './sse';
 import type {
   QuickSendParams,
@@ -63,6 +64,8 @@ export class FreeRangeNotify {
   readonly topics: TopicsClient;
   /** Presence: smart delivery check-in. */
   readonly presence: PresenceClient;
+  /** OTP-as-a-service: send / verify / resend authentication codes. */
+  readonly otp: OTPClient;
 
   constructor(apiKey: string, options?: FreeRangeNotifyOptions) {
     if (!apiKey) throw new Error('API key is required');
@@ -76,6 +79,7 @@ export class FreeRangeNotify {
     this.workflows = new WorkflowsClient(this.http);
     this.topics = new TopicsClient(this.http);
     this.presence = new PresenceClient(this.http);
+    this.otp = new OTPClient(this.http);
   }
 
   // ── Backward-compatible convenience methods ──
@@ -155,6 +159,16 @@ export { TemplatesClient } from './templates';
 export { WorkflowsClient } from './workflows';
 export { TopicsClient } from './topics';
 export { PresenceClient } from './presence';
+export { OTPClient, OTPError } from './otp';
+export type {
+  OTPChannel,
+  OTPSendParams,
+  OTPSendResult,
+  OTPVerifyParams,
+  OTPVerifyResult,
+  OTPVerifyErrorCode,
+  OTPErrorCode,
+} from './otp';
 export { connectSSE } from './sse';
 export {
   workflow,

--- a/sdk/js/src/otp.ts
+++ b/sdk/js/src/otp.ts
@@ -1,0 +1,211 @@
+import { HttpClient } from './client';
+import { FreeRangeNotifyError } from './errors';
+
+// ── Types ─────────────────────────────────────────────────────────────────
+
+export type OTPChannel = 'sms' | 'whatsapp' | 'email';
+
+export interface OTPSendParams {
+    /** Delivery channel. */
+    channel: OTPChannel;
+    /**
+     * Raw E.164 phone (`sms`/`whatsapp`) or RFC 5322 email (`email`). Mutually
+     * exclusive with {@link userId} and {@link externalId}.
+     */
+    recipient?: string;
+    /**
+     * Internal FRN `user_id` (UUID). When supplied, the channel-appropriate
+     * contact field on the user record is used as the recipient. Mutually
+     * exclusive with {@link recipient} and {@link externalId}.
+     */
+    userId?: string;
+    /**
+     * Caller-owned external identifier looked up via the users index.
+     * Mutually exclusive with {@link recipient} and {@link userId}.
+     */
+    externalId?: string;
+
+    /** Code length (4–10). Omit / 0 → server default of 6. */
+    length?: number;
+    /** Draw codes from a lookalike-free alphanumeric alphabet instead of digits. */
+    alphanumeric?: boolean;
+    /** Code lifetime in seconds (30–900). Omit → server default of 300. */
+    ttlSeconds?: number;
+    /** Verify-attempt budget (1–10). Omit → server default of 5. */
+    maxAttempts?: number;
+
+    /** Optional bring-your-own message body containing `{{code}}`. */
+    templateBody?: string;
+    /** Extra variables (e.g. `{ app_name: 'Acme' }`) for `templateBody`. */
+    templateData?: Record<string, unknown>;
+}
+
+export interface OTPSendResult {
+    request_id: string;
+    notification_id: string;
+    channel: OTPChannel;
+    expires_at: string;
+    ttl_seconds: number;
+    max_attempts: number;
+}
+
+export interface OTPVerifyParams {
+    requestId: string;
+    code: string;
+}
+
+export interface OTPVerifyResult {
+    verified: boolean;
+    request_id: string;
+    verified_at?: string;
+    attempts_remaining?: number;
+    error?: OTPVerifyErrorCode;
+}
+
+export type OTPVerifyErrorCode =
+    | 'invalid_code'
+    | 'attempts_exhausted'
+    | 'expired'
+    | 'not_found'
+    | 'internal_error';
+
+// ── Typed error ───────────────────────────────────────────────────────────
+
+/**
+ * Thrown by {@link OTPClient} for known OTP failure modes. Inspect `code` to
+ * branch — it carries the same `error` discriminator the API returns, plus a
+ * synthetic `rate_limited` / `already_verified` / `resend_cooldown` for the
+ * send/resend paths (which never reach this exception type for the verify
+ * endpoint).
+ */
+export class OTPError extends FreeRangeNotifyError {
+    code: OTPErrorCode;
+    attemptsRemaining?: number;
+
+    constructor(status: number, body: string, code: OTPErrorCode, attemptsRemaining?: number) {
+        super(status, body);
+        this.name = 'OTPError';
+        this.code = code;
+        this.attemptsRemaining = attemptsRemaining;
+    }
+}
+
+export type OTPErrorCode =
+    | OTPVerifyErrorCode
+    | 'already_verified'
+    | 'resend_cooldown'
+    | 'rate_limited';
+
+// ── Client ────────────────────────────────────────────────────────────────
+
+export class OTPClient {
+    constructor(private readonly http: HttpClient) { }
+
+    /**
+     * Generate an OTP, hash it, and dispatch it via the requested channel.
+     * Throws {@link OTPError} with `code='rate_limited'` on 429.
+     */
+    async send(params: OTPSendParams): Promise<OTPSendResult> {
+        try {
+            return await this.http.request<OTPSendResult>('POST', '/otp/send', toWire(params));
+        } catch (err) {
+            throw mapSendError(err);
+        }
+    }
+
+    /**
+     * Verify a user-supplied code against an existing `requestId`. On invalid
+     * input the SDK throws {@link OTPError}; inspect `err.code` and (for
+     * `invalid_code`) `err.attemptsRemaining` to drive UX.
+     */
+    async verify(params: OTPVerifyParams): Promise<OTPVerifyResult> {
+        try {
+            return await this.http.request<OTPVerifyResult>('POST', '/otp/verify', {
+                request_id: params.requestId,
+                code: params.code,
+            });
+        } catch (err) {
+            throw mapVerifyError(err);
+        }
+    }
+
+    /**
+     * Re-issue a fresh code for an existing `requestId` (60 s cooldown). The
+     * previous code is invalidated and the attempt counter resets.
+     */
+    async resend(requestId: string): Promise<OTPSendResult> {
+        try {
+            return await this.http.request<OTPSendResult>('POST', '/otp/resend', { request_id: requestId });
+        } catch (err) {
+            throw mapSendError(err);
+        }
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+function toWire(p: OTPSendParams): Record<string, unknown> {
+    const out: Record<string, unknown> = {
+        channel: p.channel,
+    };
+    if (p.recipient !== undefined) out.recipient = p.recipient;
+    if (p.userId !== undefined) out.user_id = p.userId;
+    if (p.externalId !== undefined) out.external_id = p.externalId;
+    if (p.length !== undefined) out.length = p.length;
+    if (p.alphanumeric !== undefined) out.alphanumeric = p.alphanumeric;
+    if (p.ttlSeconds !== undefined) out.ttl_seconds = p.ttlSeconds;
+    if (p.maxAttempts !== undefined) out.max_attempts = p.maxAttempts;
+    if (p.templateBody !== undefined) out.template_body = p.templateBody;
+    if (p.templateData !== undefined) out.template_data = p.templateData;
+    return out;
+}
+
+function mapSendError(err: unknown): unknown {
+    if (!(err instanceof FreeRangeNotifyError)) return err;
+    const body = err.body || '';
+    switch (err.status) {
+        case 404:
+            return new OTPError(err.status, body, 'not_found');
+        case 410:
+            return new OTPError(err.status, body, 'expired');
+        case 409:
+            if (body.includes('already verified')) {
+                return new OTPError(err.status, body, 'already_verified');
+            }
+            if (body.includes('cooldown')) {
+                return new OTPError(err.status, body, 'resend_cooldown');
+            }
+            return err;
+        case 429:
+            return new OTPError(err.status, body, 'rate_limited');
+        default:
+            return err;
+    }
+}
+
+function mapVerifyError(err: unknown): unknown {
+    if (!(err instanceof FreeRangeNotifyError)) return err;
+    const parsed = tryParseVerifyBody(err.body);
+    const code = parsed?.error;
+    if (code) {
+        return new OTPError(err.status, err.body, code, parsed?.attempts_remaining);
+    }
+    switch (err.status) {
+        case 404:
+            return new OTPError(err.status, err.body, 'not_found');
+        case 410:
+            return new OTPError(err.status, err.body, 'expired');
+        default:
+            return err;
+    }
+}
+
+function tryParseVerifyBody(body: string): OTPVerifyResult | undefined {
+    if (!body) return undefined;
+    try {
+        const out = JSON.parse(body) as OTPVerifyResult;
+        return out;
+    } catch {
+        return undefined;
+    }
+}

--- a/ui/src/config/appDetailNav.tsx
+++ b/ui/src/config/appDetailNav.tsx
@@ -70,7 +70,7 @@ export const TAB_GROUPS: TabGroup[] = [
         label: 'General',
         tabs: [
             { id: 'overview', label: 'Overview', icon: <LayoutDashboard className="h-4 w-4" /> },
-            { id: 'users', label: 'Users', icon: <Users className="h-4 w-4" /> },
+            { id: 'users', label: 'Subscribers', icon: <Users className="h-4 w-4" /> },
             { id: 'templates', label: 'Templates', icon: <FileText className="h-4 w-4" /> },
             { id: 'notifications', label: 'Notifications', icon: <Bell className="h-4 w-4" /> },
         ],

--- a/ui/src/config/docsNav.tsx
+++ b/ui/src/config/docsNav.tsx
@@ -13,6 +13,7 @@ import {
     Layers,
     Globe,
     IndianRupee,
+    KeyRound,
 } from 'lucide-react';
 
 export interface DocNavItem {
@@ -35,6 +36,7 @@ export const NAV_SECTIONS: DocNavSection[] = [
             { label: 'Workflows', to: '/docs/workflows', icon: <Workflow className="h-4 w-4" /> },
             { label: 'Topics', to: '/docs/topics', icon: <Tag className="h-4 w-4" /> },
             { label: 'Channels', to: '/docs/channels', icon: <Radio className="h-4 w-4" /> },
+            { label: 'OTP (Auth Codes)', to: '/docs/otp', icon: <KeyRound className="h-4 w-4" /> },
             { label: 'SSE (Real-time)', to: '/docs/sse', icon: <Zap className="h-4 w-4" /> },
             { label: 'In-App (Inbox)', to: '/docs/in-app', icon: <Inbox className="h-4 w-4" /> },
             { label: 'Environments', to: '/docs/environments', icon: <Layers className="h-4 w-4" /> },

--- a/ui/src/docs/otp.md
+++ b/ui/src/docs/otp.md
@@ -1,0 +1,304 @@
+# OTP as a Service
+
+Programmatic one-time-passcode (OTP) delivery and verification over **SMS**, **WhatsApp**, and **Email**. Use it for sign-in, sign-up, step-up auth, and transaction confirmation flows.
+
+The send path reuses the standard notification pipeline (templates, providers, credit billing). The verify path adds constant-time comparison, atomic attempt counting, and per-recipient rate limiting — security primitives that are not safe to reimplement on top of `/v1/notifications` yourself.
+
+---
+
+## Endpoints
+
+All three require the `X-API-Key` header. Your `app_id` is derived from the API key server-side — it is never accepted from the request body.
+
+| Method | Path             | Purpose                                          |
+| ------ | ---------------- | ------------------------------------------------ |
+| POST   | `/v1/otp/send`   | Generate a code, hash it, dispatch via channel   |
+| POST   | `/v1/otp/verify` | Verify a code against a `request_id`             |
+| POST   | `/v1/otp/resend` | Re-issue a fresh code (60 s cooldown per record) |
+
+---
+
+## Quick start
+
+### 1. Send a code
+
+SMS, defaults (6 digits, 5-minute TTL, 5 attempts):
+
+```bash
+curl -X POST http://localhost:8080/v1/otp/send \
+  -H "X-API-Key: $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"channel":"sms","recipient":"+14155551212"}'
+```
+
+Response (`202 Accepted`):
+
+```json
+{
+  "request_id": "550e8400-e29b-41d4-a716-446655440000",
+  "notification_id": "abc123",
+  "channel": "sms",
+  "expires_at": "2026-05-24T12:35:00Z",
+  "ttl_seconds": 300,
+  "max_attempts": 5
+}
+```
+
+Persist the `request_id` in your session/cache — your verify call needs it.
+
+### 2. Verify the code
+
+```bash
+curl -X POST http://localhost:8080/v1/otp/verify \
+  -H "X-API-Key: $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"request_id":"550e8400-e29b-41d4-a716-446655440000","code":"482913"}'
+```
+
+Success (`200 OK`):
+
+```json
+{ "verified": true, "request_id": "...", "verified_at": "2026-05-24T12:31:42Z" }
+```
+
+Wrong code (`400`):
+
+```json
+{ "verified": false, "error": "invalid_code", "attempts_remaining": 4 }
+```
+
+### 3. Resend (after the 60 s cooldown)
+
+```bash
+curl -X POST http://localhost:8080/v1/otp/resend \
+  -H "X-API-Key: $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"request_id":"550e8400-e29b-41d4-a716-446655440000"}'
+```
+
+The previous code is invalidated, a fresh code is generated, and the attempt counter resets.
+
+---
+
+## Channels & recipient formats
+
+There are **three ways** to identify the recipient. Supply exactly one of `recipient`, `user_id`, or `external_id` in the request body. The `channel` field always selects which contact address is used.
+
+| Identifier      | What you pass                                | When to use                                                      |
+| --------------- | -------------------------------------------- | ---------------------------------------------------------------- |
+| `recipient`     | Raw email or E.164 phone                     | Anonymous flows; first-time users. Auto-creates a user record.   |
+| `user_id`       | Internal FRN `user_id` (UUID)                | You stored FRN's `user_id` when creating the user.               |
+| `external_id`   | Your own user identifier                     | You stored your customer ID as the user's `external_id`.         |
+
+When `user_id` or `external_id` is supplied, the channel-appropriate contact field is read from the stored user record:
+
+| Channel    | Reads from `user`           | Raw `recipient` format     |
+| ---------- | --------------------------- | -------------------------- |
+| `sms`      | `phone`                     | E.164, e.g. `+14155551212` |
+| `whatsapp` | `phone`                     | E.164, e.g. `+14155551212` |
+| `email`    | `email`                     | RFC 5322 address           |
+
+If the resolved user has no value for the field the channel needs (e.g. `channel=sms` but the user record has no `phone`), the API returns `400` with `error: "otp: resolved user has no address for the requested channel"`.
+
+The first send to a *raw* recipient auto-creates a user record with `email_enabled`, `sms_enabled`, and `whatsapp_enabled` all `true`. Sends by `user_id` / `external_id` never auto-create.
+
+### Examples
+
+Send by `external_id`:
+
+```bash
+curl -X POST https://api.freerangenotify.com/v1/otp/send \
+  -H "X-API-Key: $FRN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"channel":"email","external_id":"customer_ext_42"}'
+```
+
+Send by internal `user_id`:
+
+```bash
+curl -X POST https://api.freerangenotify.com/v1/otp/send \
+  -H "X-API-Key: $FRN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"channel":"sms","user_id":"11111111-2222-3333-4444-555555555555"}'
+```
+
+---
+
+## Customising the message body
+
+Bring-your-own body via `template_body`. It **must** contain a `{{code}}` placeholder.
+
+| Placeholder                              | Value                                |
+| ---------------------------------------- | ------------------------------------ |
+| `{{code}}`, `{{ code }}`, `{{.code}}`    | The generated OTP                    |
+| `{{ttl}}`, `{{ ttl }}`, `{{.ttl}}`       | TTL **in minutes** (e.g. `5`)        |
+| `{{<key>}}` from `template_data`         | Any extra string variable you pass   |
+
+Example:
+
+```json
+{
+  "channel": "whatsapp",
+  "recipient": "+14155551212",
+  "template_body": "Your {{app_name}} code is {{code}}. Expires in {{ttl}} minutes.",
+  "template_data": { "app_name": "Acme" }
+}
+```
+
+If `template_body` is omitted, a channel-appropriate default is used (e.g. `Your verification code is 482913. It expires in 5 minutes.`).
+
+---
+
+## Code generation knobs
+
+| Field          | Default | Range  | Notes                                                                                          |
+| -------------- | ------- | ------ | ---------------------------------------------------------------------------------------------- |
+| `length`       | 6       | 4–10   | Number of characters in the code.                                                              |
+| `alphanumeric` | false   |        | When `true`, draws from `ABCDEFGHJKLMNPQRSTUVWXYZ23456789` — lookalikes `0/O`, `1/I/l` excluded. |
+| `ttl_seconds`  | 300     | 30–900 | Code lifetime (max 15 minutes).                                                                |
+| `max_attempts` | 5       | 1–10   | Verify attempts allowed before `attempts_exhausted`.                                            |
+
+---
+
+## Security model
+
+- **Storage** — Only `SHA-256(code + 16-byte random salt)` is persisted in Redis. The plaintext code is discarded immediately after dispatch and is **never logged**.
+- **Verification** — `crypto/subtle.ConstantTimeCompare` guards against timing oracles. Attempt counting uses an atomic Redis `WATCH/MULTI` loop so concurrent guesses cannot exceed `max_attempts`.
+- **Per-recipient rate limit** — Fixed window of 5 sends per `(app_id, recipient)` per 10 minutes. Exceeding it returns `429`.
+- **Resend cooldown** — 60 seconds per `request_id`, enforced server-side.
+- **Tenant isolation** — `app_id` comes from the API key, never the body. Each record is keyed by a v4 UUID, so cross-tenant `request_id` access is impossible.
+
+---
+
+## Error reference
+
+| HTTP | `error`              | Cause                                                            | Endpoint(s)             |
+| ---- | -------------------- | ---------------------------------------------------------------- | ----------------------- |
+| 400  | _validation message_ | Bad JSON or DTO violation                                        | send / verify / resend  |
+| 400  | _validation message_ | Invalid channel, recipient, length, TTL, attempts, or template   | send / resend           |
+| 400  | `otp: provide exactly one of recipient, user_id, or external_id` | More than one identifier supplied | send |
+| 400  | `otp: resolved user has no address for the requested channel` | Resolved user lacks `email`/`phone` for the chosen channel | send |
+| 400  | `invalid_code`       | Code mismatch (response also carries `attempts_remaining`)       | verify                  |
+| 400  | `attempts_exhausted` | `max_attempts` reached on this `request_id`                      | verify                  |
+| 401  | _auth message_       | Missing / invalid `X-API-Key`                                    | all                     |
+| 404  | `not_found`          | `request_id` does not exist (or already expired and purged)      | verify / resend         |
+| 404  | `otp: user not found` | `user_id` / `external_id` does not match any user in this app   | send                    |
+| 409  | `already_verified`   | The OTP was already consumed                                     | resend                  |
+| 409  | `resend_cooldown`    | Within the 60 s cooldown                                         | resend                  |
+| 410  | `expired`            | OTP TTL elapsed                                                  | verify / resend         |
+| 429  | `rate_limited`       | Per-recipient send budget exceeded                               | send / resend           |
+| 500  | `internal_error`     | Unhandled server failure                                         | all                     |
+
+---
+
+## Billing
+
+Each `send` and each `resend` dispatches one notification through the standard pipeline, which charges the per-channel credit rate just like `/v1/notifications`. **There is no separate OTP rate card.** The OTP endpoints are a thin security policy layer (generate → hash → verify) on top of channels you are already paying for.
+
+See [Pricing & Credits](/docs/pricing) for current per-channel rates.
+
+---
+
+## Dashboard surface
+
+The OTP API is intentionally **programmatic-only** in v1 — there are no dedicated OTP authoring or inspection screens in the dashboard, by design:
+
+- OTP records are short-lived (≤ 15 minutes) and security-sensitive. The plaintext code is never persisted, so a "recent OTPs" panel could only display hashes (useless) or, worse, leak plaintext into the UI.
+- Standard delivery analytics (provider status, latency, cost) for each OTP are already visible via the linked `notification_id` in the existing **Notifications** view.
+
+If you need an "OTP diagnostics" panel that surfaces `request_id`, channel, status, and attempts (without ever exposing the code), tell us — it's a candidate for a future release.
+
+---
+
+## See also
+
+- [API Reference](/docs/api) — full OpenAPI schemas (`docs/openapi/otp.yaml`)
+- [Channels](/docs/channels) — underlying SMS / WhatsApp / Email provider configuration
+- [Pricing & Credits](/docs/pricing) — per-channel credit rates
+
+---
+
+## SDK usage
+
+Both the Go and JavaScript/TypeScript SDKs ship typed wrappers under the `OTP` / `otp` sub-client. Use them instead of raw HTTP — they map every API failure mode to a typed error you can branch on without parsing response bodies.
+
+### Go
+
+```go
+import (
+    "context"
+    "errors"
+
+    "github.com/the-monkeys/freerangenotify/sdk/go/freerangenotify"
+)
+
+client := freerangenotify.New("frn_xxx")
+
+// 1. Send
+res, err := client.OTP.Send(ctx, freerangenotify.OTPSendParams{
+    Channel:   freerangenotify.OTPChannelSMS,
+    Recipient: "+14155551212",
+})
+if errors.Is(err, freerangenotify.ErrOTPRateLimited) {
+    // back off
+}
+if err != nil { return err }
+
+// 2. Verify
+verify, err := client.OTP.Verify(ctx, freerangenotify.OTPVerifyParams{
+    RequestID: res.RequestID,
+    Code:      userInput,
+})
+switch {
+case errors.Is(err, freerangenotify.ErrOTPInvalidCode):
+    // show "wrong code, X attempts left" using verify.AttemptsRemaining
+case errors.Is(err, freerangenotify.ErrOTPAttemptsExhausted):
+    // lock the form
+case errors.Is(err, freerangenotify.ErrOTPExpired):
+    // prompt to resend
+case err != nil:
+    return err
+default:
+    // verify.Verified == true
+}
+
+// 3. Resend
+_, _ = client.OTP.Resend(ctx, res.RequestID)
+```
+
+Sentinel errors: `ErrOTPInvalidCode`, `ErrOTPAttemptsExhausted`, `ErrOTPExpired`, `ErrOTPNotFound`, `ErrOTPAlreadyVerified`, `ErrOTPResendCooldown`, `ErrOTPRateLimited`. The underlying `*APIError` is still reachable via `errors.As` if you need the raw HTTP status / body.
+
+### TypeScript / JavaScript
+
+```ts
+import { FreeRangeNotify, OTPError } from '@freerangenotify/sdk';
+
+const client = new FreeRangeNotify('frn_xxx');
+
+// 1. Send
+const res = await client.otp.send({
+    channel: 'sms',
+    recipient: '+14155551212',
+});
+
+// 2. Verify
+try {
+    const verify = await client.otp.verify({ requestId: res.request_id, code: userInput });
+    // verify.verified === true
+} catch (err) {
+    if (err instanceof OTPError) {
+        switch (err.code) {
+            case 'invalid_code':       /* show err.attemptsRemaining */ break;
+            case 'attempts_exhausted': /* lock the form */              break;
+            case 'expired':            /* prompt to resend */           break;
+            case 'not_found':          /* session lost */               break;
+            default: throw err;
+        }
+    } else { throw err; }
+}
+
+// 3. Resend
+await client.otp.resend(res.request_id);
+```
+
+`OTPError.code` values: `invalid_code` · `attempts_exhausted` · `expired` · `not_found` · `already_verified` · `resend_cooldown` · `rate_limited`.


### PR DESCRIPTION
OTP send API now accepts one of three mutually-exclusive identifiers in the request body: recipient (legacy raw email/phone), user_id (internal FRN UUID), or external_id (caller-owned). The chosen channel (email|sms|whatsapp) decides which contact field on the resolved user record is used to deliver the code.

Changes:

- domain/otp: SendInput.UserID/ExternalID + sentinels ErrAmbiguousRecipient, ErrUserNotFound, ErrUserMissingChannelAddress.

- usecases/services: resolveRecipient + channelAddressForUser; validateSendInput enforces 'exactly one'; dispatchNotification accepts a pre-resolved user so we skip auto-create when resolving by id/external_id; tenancy guard rejects cross-app user_id lookups.

- http/dto + handler: new fields and error mapping (400 ambiguous / missing channel address; 404 user not found).

- SDKs (Go + JS): new optional UserID/ExternalID fields with omitempty wire emission.

- Docs: OpenAPI examples, API_DOCUMENTATION.md and ui/src/docs/otp.md updated with identifier-options table and curl examples.

- Tests: 6 new service tests covering external_id resolution, user_id resolution, cross-tenant rejection, not-found, missing channel address, ambiguous, and missing identifier.